### PR TITLE
19 do not decide whether a suite has passed or not

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,6 @@ inputs:
       container using the [ogccite/teamengine-production:1.0-SNAPSHOT](https://hub.docker.com/r/ogccite/teamengine-production) image.
       If you specify a custom teamengine URL you may also optonally supply authentication credentials by defining
       them as secrets - Expected secret names are: `teamengine_username` and `teamengine_password`.
-  treat_skipped_tests_as_failures:
-    required: false
-    default: "true"
-    description: Whether to treat skipped tests as an indication of failure or not.
   teamengine_username:
     required: false
     default: "ogctest"
@@ -101,7 +97,6 @@ runs:
         poetry run cite-runner \
             parse-result \
             --output-format=markdown \
-            ${{ fromJSON(inputs.treat_skipped_tests_as_failures) && '--treat-skipped-tests-as-failures' || '' }} \
             ${{ steps.run_executable_test_suite.outputs.RAW_RESULT_OUTPUT_PATH }} 1> ${md_result_output_path}
         echo "MARKDOWN_RESULT_OUTPUT_PATH=${{ github.action_path }}/${md_result_output_path}" >> "${GITHUB_OUTPUT}"
     - name: 'store execution results as artifacts'

--- a/src/cite_runner/parsers/earl.py
+++ b/src/cite_runner/parsers/earl.py
@@ -18,11 +18,14 @@ from ..teamengine_runner import logger
 
 def parse_test_suite_result(
     suite_result: etree.Element,
-    treat_skipped_as_failure: bool,
 ) -> models.TestSuiteResult:
     """Parse test suite result from EARL."""
     test_run_el = suite_result.find("./cite:TestRun", namespaces=suite_result.nsmap)
     suite_title = test_run_el.find("dct:title", namespaces=suite_result.nsmap).text
+    raw_passed = test_run_el.find(
+        "cite:areCoreConformanceClassesPassed", namespaces=suite_result.nsmap
+    ).text
+    passed = True if raw_passed.upper() == "TRUE" else False
     suite_identifier = test_run_el.find(
         "dct:identifier", namespaces=suite_result.nsmap
     ).text
@@ -61,12 +64,6 @@ def parse_test_suite_result(
                 f"test case {test_case_result.identifier} is not part of any "
                 f"conformance class"
             )
-    passed = False
-    if num_failed == 0:
-        if num_skipped == 0:
-            passed = True
-        elif not treat_skipped_as_failure:
-            passed = True
     return models.TestSuiteResult(
         suite_identifier=suite_identifier,
         suite_title=suite_title,

--- a/src/cite_runner/teamengine_runner.py
+++ b/src/cite_runner/teamengine_runner.py
@@ -20,9 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class SuiteParserProtocol(typing.Protocol):
-    def __call__(
-        self, suite_result: etree.Element, treat_skipped_as_failure: bool
-    ) -> models.TestSuiteResult: ...
+    def __call__(self, suite_result: etree.Element) -> models.TestSuiteResult: ...
 
 
 class SuiteSerializerProtocol(typing.Protocol):
@@ -92,14 +90,13 @@ def execute_test_suite(
 def parse_test_suite_result(
     raw_result: str,
     settings: config.CiteRunnerSettings,
-    treat_skipped_as_failure: bool,
     test_suite_identifier: str | None = None,
 ) -> models.TestSuiteResult:
     root_element = _parse_raw_result_as_xml(raw_result)
     parser: SuiteParserProtocol = _get_suite_result_parser(
         settings, test_suite_identifier
     )
-    return parser(root_element, treat_skipped_as_failure=treat_skipped_as_failure)
+    return parser(root_element)
 
 
 def serialize_suite_result(

--- a/src/cite_runner/templates/test-suite-result.md
+++ b/src/cite_runner/templates/test-suite-result.md
@@ -2,12 +2,11 @@
 
 
 {%- if result.passed %}
-- **🏅 Test suite has passed!**
-
-  This means that teamengine reported that all core conformance classes have passed.
+- **🏅 Test suite has passed!** - Teamengine reported that all core conformance classes have passed.
 
 {%- else %}
-- **❌ Test suite has failed**
+- **❌ Test suite has failed** - Teamengine reported that all core conformance classes have failed.
+
 {%- endif %}
 
 - Ran {{ result.num_tests_total }} tests in {{ result.test_run_duration | humanize_precisedelta(minimum_unit="milliseconds") }}

--- a/src/cite_runner/templates/test-suite-result.md
+++ b/src/cite_runner/templates/test-suite-result.md
@@ -3,6 +3,9 @@
 
 {%- if result.passed %}
 - **🏅 Test suite has passed!**
+
+  This means that teamengine reported that all core conformance classes have passed.
+
 {%- else %}
 - **❌ Test suite has failed**
 {%- endif %}

--- a/tests/data/raw-result-ogcapi-features-1.0-earl.xml
+++ b/tests/data/raw-result-ogcapi-features-1.0-earl.xml
@@ -1,12 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF
-        xmlns:dct="http://purl.org/dc/terms/"
-        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-        xmlns:http="http://www.w3.org/2011/http#"
-        xmlns:cnt="http://www.w3.org/2011/content#"
-        xmlns:earl="http://www.w3.org/ns/earl#"
-        xmlns:cite="http://cite.opengeospatial.org/"
->
+<?xml version="1.0" encoding="UTF-8"?><rdf:RDF xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:http="http://www.w3.org/2011/http#" xmlns:cnt="http://www.w3.org/2011/content#" xmlns:earl="http://www.w3.org/ns/earl#" xmlns:cite="http://cite.opengeospatial.org/">
   <earl:Assertion rdf:about="assert-5">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy>
@@ -20,8 +12,8 @@
     </earl:subject>
     <earl:result>
       <earl:TestResult rdf:about="result-5">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.629Z</dct:date>
-        <dct:description>java.lang.AssertionError: Geometry 'POLYGON ((106.57998579307912 52.79998159444554, 106.53998823448521 52.93999888774037, 107.0800069519353 53.18001007751998, 107.2999935242018 53.37999787048953, 107.59997521365611 53.51998932556822, 108.03994835818912 53.859968573616456, 108.37997928266967 54.25999583598784, 109.05270307824526 55.027597561251326, 109.19346967980832 55.53560272889659, 109.50699059452313 55.73091380474372, 109.92980716353523 55.7129562445223, 109.70000206913326 54.980003567110515, 109.66000451053935 54.71999359803395, 109.47996382043448 54.33999095317566, 109.31997358605884 53.81999685323869, 109.22003136600637 53.619983222052994, 108.99999311730755 53.78002513286093, 108.60001753136845 53.4399942083804, 108.800005324338 53.37999787048953, 108.76000776574409 53.200008856816936, 108.45997439985749 53.14001251892607, 108.17999148970011 52.79998159444554, 107.79996300662566 52.579995022179034, 107.31999230349876 52.42000478780339, 106.64003380740229 52.32001089131862, 106.1000150899522 52.03997630472897, 105.740037062607 51.759993394571595, 105.24001590375084 51.52000804300813, 104.81998986208251 51.46001170511727, 104.30002160036167 51.50000926371118, 103.7600028829116 51.60000316019595, 103.6200114278329 51.73999461527464, 103.85999677939637 51.85998729105637, 104.39996382041414 51.85998729105637, 105.05997521364597 52.0000045843512, 105.4800012553143 52.28001333272471, 105.98002241417046 52.51999868428817, 106.26000532432784 52.619992580772944, 106.57998579307912 52.79998159444554))' outside bounding box: '-180.0000000,85.0000000,180.0000000,90.0000000'.</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.739Z</dct:date>
+        <dct:description>java.lang.AssertionError: Geometry 'POINT (-75 45)' outside bounding box: '-80.0000000,-5.0000000,-70.0000000,5.0000000'.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
         <cite:message>
           <http:Request>
@@ -53,41 +45,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-176">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.524Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned">
-        <dct:title>validate Features Response_ Number Returned </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 22, Test Method 7 (Requirement /req/core/fc-response) - Abstract Test 26 (Requirement /req/core/fc-numberReturned)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-188">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-188">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.423Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollection#validateFeatureCollectionMetadataResponse">
-        <dct:title>validate Feature Collection Metadata Response </dct:title>
-        <dct:description>Implements A.2.6. Feature Collection {root}/collections/{collectionId}, Abstract Test 12 (Requirement /req/core/sfc-md-success)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-140">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-140">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.129Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.52Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
@@ -98,22 +56,51 @@
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
+  <earl:Assertion rdf:about="assert-188">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-188">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.656Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched">
+        <dct:title>validate Features With Limit Response_ Number Matched </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 22, Test Method 6 (Requirement /req/core/fc-response) - Abstract Test 25 (Requirement /req/core/fc-numberMatched)</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-140">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-140">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.493Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84">
+        <dct:title>validate Features Response_ Geometry In CRS84 </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 2, Test Method 2 (Requirement /req/core/crs84)</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
   <earl:Assertion rdf:about="assert-152">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-152">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.04Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.767Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned">
-        <dct:title>validate Features Response_ Number Returned </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 22, Test Method 7 (Requirement /req/core/fc-response) - Abstract Test 26 (Requirement /req/core/fc-numberReturned)</dct:description>
-      </earl:TestCase>
-    </earl:test>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-164">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -121,14 +108,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-164">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.166Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.895Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition">
-        <dct:title>bounding Box Parameter Definition </dct:title>
-        <dct:description>A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 14: (Requirement /req/core/fc-bbox-definition)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links">
+        <dct:title>validate Features With Bounding Box Response_ Links </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 22, Test Method 4 (Requirement /req/core/fc-response) - Abstract Test 23 (Requirement /req/core/fc-links, /req/core/fc-rel-type)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -138,14 +125,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-273">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.709Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.924Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameter">
-        <dct:title>verify Bbox Crs Parameter </dct:title>
-        <dct:description>Implements A.2.2 Query, Parameter bbox-crs, Abstract Test 8 (Requirement /req/crs/fc-bbox-crs-definition, /req/crs/bbox-crs-action)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsDefaultCrs#verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs">
+        <dct:title>verify Collections Path Collection Crs Property Contains Default Crs </dct:title>
+        <dct:description>Implements A.1 Discovery, Abstract Test 2 (Requirement /req/crs/fc-md-crs-list B), crs property contains default crs in the collection objects in the path /collections</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -155,14 +142,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-261">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.651Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.907Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterDefault#verifyFeatureCrsParameterDefault">
-        <dct:title>verify Feature Crs Parameter Default </dct:title>
-        <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 6 (Requirement /req/crs/fc-crs-default-value, /req/crs/ogc-crs-header, /req/crs/ogc-crs-header-value),  Default CRS requesting path /collections/{collectionId}/items/{featureId}</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCollectionCrsIdentifierOfCrsProperty">
+        <dct:title>verify Collections Collection Crs Identifier Of Crs Property </dct:title>
+        <dct:description>Implements A.1 Discovery, Abstract Test 1 (Requirement /req/crs/crs-uri, /req/crs/fc-md-crs-list A, /req/crs/fc-md-storageCrs, /req/crs/fc-md-crs-list-global), crs property in the collection objects in the path /collections</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -172,8 +159,8 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-6">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.606Z</dct:date>
-        <dct:description>java.lang.AssertionError: Geometry 'POINT (-75 45)' outside bounding box: '-180.0000000,-90.0000000,180.0000000,-85.0000000'.</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.446Z</dct:date>
+        <dct:description>java.lang.AssertionError: Required datetime parameter for collections with path '/collections/lakes/items'  in OpenAPI document is missing expected object to not be null</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
         <cite:message>
           <http:Request>
@@ -192,7 +179,12 @@
         </cite:message>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition">
+        <dct:title>time Parameter Definition </dct:title>
+        <dct:description>A.2.7. Features {root}/collections/{collectionId}/items - Datetime, Abstract Test 18: (Requirement /req/core/fc-time-definition)</dct:description>
+      </earl:TestCase>
+    </earl:test>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-165">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -200,14 +192,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-165">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.441Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.593Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84">
-        <dct:title>validate Features Response_ Geometry In CRS84 </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 2, Test Method 2 (Requirement /req/core/crs84)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links">
+        <dct:title>validate Features With Limit Response_ Links </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 22, Test Method 4 (Requirement /req/core/fc-response) - Abstract Test 23 (Requirement /req/core/fc-links, /req/core/fc-rel-type)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -217,16 +209,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-177">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.38Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.46Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation">
-        <dct:title>validate Features With Limit Operation </dct:title>
-        <dct:description>A.2.7. Features {root}/collections/{collectionId}/items - Limit, Abstract Test 13: (Requirement /req/core/fc-op)</dct:description>
-      </earl:TestCase>
-    </earl:test>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-189">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -234,16 +221,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-189">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.677Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.59Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links">
-        <dct:title>validate Features With Bounding Box Response_ Links </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 22, Test Method 4 (Requirement /req/core/fc-response) - Abstract Test 23 (Requirement /req/core/fc-links, /req/core/fc-rel-type)</dct:description>
-      </earl:TestCase>
-    </earl:test>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-141">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -251,11 +233,16 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-141">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.589Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.023Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation">
+        <dct:title>validate Features With Bounding Box Operation </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 13: (Requirement /req/core/fc-op)</dct:description>
+      </earl:TestCase>
+    </earl:test>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-153">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -263,16 +250,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-153">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.343Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.757Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_NumberReturned">
-        <dct:title>validate Features Response_ Number Returned </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 22, Test Method 7 (Requirement /req/core/fc-response) - Abstract Test 26 (Requirement /req/core/fc-numberReturned)</dct:description>
-      </earl:TestCase>
-    </earl:test>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-274">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -280,7 +262,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-274">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.735Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.288Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
@@ -297,7 +279,24 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-262">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.447Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.244Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithCrsParameter">
+        <dct:title>verify Features Crs Parameter Transform With Crs Parameter </dct:title>
+        <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 7 (Requirement /req/crs/crs-action), Transformed geometries in the path /collections/{collectionId}/items</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-250">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-250">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.915Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
@@ -308,31 +307,14 @@
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
-  <earl:Assertion rdf:about="assert-250">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-250">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.542Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameter#verifyFeatureCrsParameter">
-        <dct:title>verify Feature Crs Parameter </dct:title>
-        <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 1 (Requirement /req/crs/fc-crs-definition, /req/crs/fc-crs-valid-value B, /req/crs/ogc-crs-header, /req/crs/ogc-crs-header-value, /req/crs/geojson), Content-Crs header in the path /collections/{collectionId}/items/{featureId}</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
   <earl:Assertion rdf:about="assert-3">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-3">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.625Z</dct:date>
-        <dct:description>java.lang.AssertionError: Geometry 'POLYGON ((106.57998579307912 52.79998159444554, 106.53998823448521 52.93999888774037, 107.0800069519353 53.18001007751998, 107.2999935242018 53.37999787048953, 107.59997521365611 53.51998932556822, 108.03994835818912 53.859968573616456, 108.37997928266967 54.25999583598784, 109.05270307824526 55.027597561251326, 109.19346967980832 55.53560272889659, 109.50699059452313 55.73091380474372, 109.92980716353523 55.7129562445223, 109.70000206913326 54.980003567110515, 109.66000451053935 54.71999359803395, 109.47996382043448 54.33999095317566, 109.31997358605884 53.81999685323869, 109.22003136600637 53.619983222052994, 108.99999311730755 53.78002513286093, 108.60001753136845 53.4399942083804, 108.800005324338 53.37999787048953, 108.76000776574409 53.200008856816936, 108.45997439985749 53.14001251892607, 108.17999148970011 52.79998159444554, 107.79996300662566 52.579995022179034, 107.31999230349876 52.42000478780339, 106.64003380740229 52.32001089131862, 106.1000150899522 52.03997630472897, 105.740037062607 51.759993394571595, 105.24001590375084 51.52000804300813, 104.81998986208251 51.46001170511727, 104.30002160036167 51.50000926371118, 103.7600028829116 51.60000316019595, 103.6200114278329 51.73999461527464, 103.85999677939637 51.85998729105637, 104.39996382041414 51.85998729105637, 105.05997521364597 52.0000045843512, 105.4800012553143 52.28001333272471, 105.98002241417046 52.51999868428817, 106.26000532432784 52.619992580772944, 106.57998579307912 52.79998159444554))' outside bounding box: '177.0000000,65.0000000,-177.0000000,70.0000000'.</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.798Z</dct:date>
+        <dct:description>java.lang.AssertionError: Geometry 'POLYGON ((106.57998579307912 52.79998159444554, 106.53998823448521 52.93999888774037, 107.0800069519353 53.18001007751998, 107.2999935242018 53.37999787048953, 107.59997521365611 53.51998932556822, 108.03994835818912 53.859968573616456, 108.37997928266967 54.25999583598784, 109.05270307824526 55.027597561251326, 109.19346967980832 55.53560272889659, 109.50699059452313 55.73091380474372, 109.92980716353523 55.7129562445223, 109.70000206913326 54.980003567110515, 109.66000451053935 54.71999359803395, 109.47996382043448 54.33999095317566, 109.31997358605884 53.81999685323869, 109.22003136600637 53.619983222052994, 108.99999311730755 53.78002513286093, 108.60001753136845 53.4399942083804, 108.800005324338 53.37999787048953, 108.76000776574409 53.200008856816936, 108.45997439985749 53.14001251892607, 108.17999148970011 52.79998159444554, 107.79996300662566 52.579995022179034, 107.31999230349876 52.42000478780339, 106.64003380740229 52.32001089131862, 106.1000150899522 52.03997630472897, 105.740037062607 51.759993394571595, 105.24001590375084 51.52000804300813, 104.81998986208251 51.46001170511727, 104.30002160036167 51.50000926371118, 103.7600028829116 51.60000316019595, 103.6200114278329 51.73999461527464, 103.85999677939637 51.85998729105637, 104.39996382041414 51.85998729105637, 105.05997521364597 52.0000045843512, 105.4800012553143 52.28001333272471, 105.98002241417046 52.51999868428817, 106.26000532432784 52.619992580772944, 106.57998579307912 52.79998159444554))' outside bounding box: '-180.0000000,-90.0000000,180.0000000,-85.0000000'.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
         <cite:message>
           <http:Request>
@@ -359,14 +341,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-90">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.37Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.444Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp">
-        <dct:title>validate Features With Limit Response_ Time Stamp </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 22, Test Method 5 (Requirement /req/core/fc-response) - Abstract Test 24 (Requirement /req/core/fc-timeStamp)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollection#validateFeatureCollectionMetadataResponse">
+        <dct:title>validate Feature Collection Metadata Response </dct:title>
+        <dct:description>Implements A.2.6. Feature Collection {root}/collections/{collectionId}, Abstract Test 12 (Requirement /req/core/sfc-md-success)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -376,14 +358,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-198">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.354Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.875Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TypeProperty">
-        <dct:title>validate Features Response_ Type Property </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 22, Test Method 1 (Requirement /req/core/fc-response)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty">
+        <dct:title>validate Features With Limit Response_ Type Property </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 22, Test Method 1 (Requirement /req/core/fc-response)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -393,11 +375,16 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-150">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.066Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.171Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_GeometryInCRS84">
+        <dct:title>validate Features Response_ Geometry In CRS84 </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 2, Test Method 2 (Requirement /req/core/crs84)</dct:description>
+      </earl:TestCase>
+    </earl:test>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-162">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -405,11 +392,16 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-162">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.431Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.415Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollection#validateFeatureCollectionMetadataResponse"/>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation">
+        <dct:title>validate Features With Limit Operation </dct:title>
+        <dct:description>A.2.7. Features {root}/collections/{collectionId}/items - Limit, Abstract Test 13: (Requirement /req/core/fc-op)</dct:description>
+      </earl:TestCase>
+    </earl:test>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-174">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -417,7 +409,24 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-174">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.667Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.469Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse">
+        <dct:title>validate Features With Limit Response </dct:title>
+        <dct:description>A.2.7. Features {root}/collections/{collectionId}/items - Limit, Abstract Test 17: (Requirement /req/core/fc-limit-response)</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-186">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-186">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.829Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
@@ -428,37 +437,20 @@
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
-  <earl:Assertion rdf:about="assert-186">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-186">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.981Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty">
-        <dct:title>validate Features With Bounding Box Response_ Type Property </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 22, Test Method 1 (Requirement /req/core/fc-response)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
   <earl:Assertion rdf:about="assert-271">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-271">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.598Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.159Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterDefault#verifyFeaturesCrsParameterDefault">
-        <dct:title>verify Features Crs Parameter Default </dct:title>
-        <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 6 (Requirement /req/crs/fc-crs-default-value, /req/crs/ogc-crs-header, /req/crs/ogc-crs-header-value), Default CRS requesting path /collections/{collectionId}/items</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameterWithDefaultCrs">
+        <dct:title>verify Bbox Crs Parameter With Default Crs </dct:title>
+        <dct:description>Implements A.2.2 Query, Parameter bbox-crs, Abstract Test 8 (Requirement /req/crs/fc-bbox-crs-definition, /req/crs/bbox-crs-action)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -468,8 +460,8 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-4">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.596Z</dct:date>
-        <dct:description>java.lang.AssertionError: Geometry 'POINT (-75 45)' outside bounding box: '-1.5000000,50.0000000,1.5000000,53.0000000'.</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.78Z</dct:date>
+        <dct:description>java.lang.AssertionError: Geometry 'POLYGON ((106.57998579307912 52.79998159444554, 106.53998823448521 52.93999888774037, 107.0800069519353 53.18001007751998, 107.2999935242018 53.37999787048953, 107.59997521365611 53.51998932556822, 108.03994835818912 53.859968573616456, 108.37997928266967 54.25999583598784, 109.05270307824526 55.027597561251326, 109.19346967980832 55.53560272889659, 109.50699059452313 55.73091380474372, 109.92980716353523 55.7129562445223, 109.70000206913326 54.980003567110515, 109.66000451053935 54.71999359803395, 109.47996382043448 54.33999095317566, 109.31997358605884 53.81999685323869, 109.22003136600637 53.619983222052994, 108.99999311730755 53.78002513286093, 108.60001753136845 53.4399942083804, 108.800005324338 53.37999787048953, 108.76000776574409 53.200008856816936, 108.45997439985749 53.14001251892607, 108.17999148970011 52.79998159444554, 107.79996300662566 52.579995022179034, 107.31999230349876 52.42000478780339, 106.64003380740229 52.32001089131862, 106.1000150899522 52.03997630472897, 105.740037062607 51.759993394571595, 105.24001590375084 51.52000804300813, 104.81998986208251 51.46001170511727, 104.30002160036167 51.50000926371118, 103.7600028829116 51.60000316019595, 103.6200114278329 51.73999461527464, 103.85999677939637 51.85998729105637, 104.39996382041414 51.85998729105637, 105.05997521364597 52.0000045843512, 105.4800012553143 52.28001333272471, 105.98002241417046 52.51999868428817, 106.26000532432784 52.619992580772944, 106.57998579307912 52.79998159444554))' outside bounding box: '-80.0000000,-5.0000000,-70.0000000,5.0000000'.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
         <cite:message>
           <http:Request>
@@ -496,11 +488,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-91">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.637Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.445Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-187">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -508,14 +500,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-187">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.431Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.671Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition">
-        <dct:title>time Parameter Definition </dct:title>
-        <dct:description>A.2.7. Features {root}/collections/{collectionId}/items - Datetime, Abstract Test 18: (Requirement /req/core/fc-time-definition)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned">
+        <dct:title>validate Features Response_ Number Returned </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 22, Test Method 7 (Requirement /req/core/fc-response) - Abstract Test 26 (Requirement /req/core/fc-numberReturned)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -525,14 +517,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-199">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.104Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.185Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse">
-        <dct:title>validate Features With Limit Response </dct:title>
-        <dct:description>A.2.7. Features {root}/collections/{collectionId}/items - Limit, Abstract Test 17: (Requirement /req/core/fc-limit-response)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_Links">
+        <dct:title>validate Features Response_ Links </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 22, Test Method 4 (Requirement /req/core/fc-response) - Abstract Test 23 (Requirement /req/core/fc-links, /req/core/fc-rel-type)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -542,11 +534,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-151">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.021Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.542Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-163">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -554,14 +546,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-163">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.196Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.27Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links">
-        <dct:title>validate Features With Limit Response_ Links </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 22, Test Method 4 (Requirement /req/core/fc-response) - Abstract Test 23 (Requirement /req/core/fc-links, /req/core/fc-rel-type)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_NumberReturned">
+        <dct:title>validate Features Response_ Number Returned </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 22, Test Method 7 (Requirement /req/core/fc-response) - Abstract Test 26 (Requirement /req/core/fc-numberReturned)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -571,11 +563,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-175">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.437Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.503Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-272">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -583,24 +575,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-272">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.59Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterInvalid#verifyFeatureCrsParameterInvalid">
-        <dct:title>verify Feature Crs Parameter Invalid </dct:title>
-        <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 1 (Requirement /req/crs/fc-crs-valid-value), Invalid CRS requesting path /collections/{collectionId}/items/{featureId}</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-260">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-260">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.671Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.209Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
@@ -611,20 +586,37 @@
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
+  <earl:Assertion rdf:about="assert-260">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-260">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.918Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCrsIdentifierOfStorageCrs">
+        <dct:title>verify Collections Crs Identifier Of Storage Crs </dct:title>
+        <dct:description>Implements A.1 Discovery, Abstract Test 1 (Requirement /req/crs/crs-uri, /req/crs/fc-md-crs-list A, /req/crs/fc-md-storageCrs, /req/crs/fc-md-crs-list-global), storageCrs property in the collections object in the path /collections</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
   <earl:Assertion rdf:about="assert-277">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-277">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.461Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.186Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionDefaultCrs#verifyCollectionCrsIdentifierOfCrsProperty">
-        <dct:title>verify Collection Crs Identifier Of Crs Property </dct:title>
-        <dct:description>Implements A.1 Discovery, Abstract Test 2 (Requirement /req/crs/fc-md-crs-list B), crs property contains default crs in the collection object in the path /collection</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterDefault#verifyFeatureCrsParameterDefault">
+        <dct:title>verify Feature Crs Parameter Default </dct:title>
+        <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 6 (Requirement /req/crs/fc-crs-default-value, /req/crs/ogc-crs-header, /req/crs/ogc-crs-header-value),  Default CRS requesting path /collections/{collectionId}/items/{featureId}</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -634,14 +626,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-265">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.682Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.91Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithCrsParameter">
-        <dct:title>verify Features Crs Parameter Transform With Crs Parameter </dct:title>
-        <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 7 (Requirement /req/crs/crs-action), Transformed geometries in the path /collections/{collectionId}/items</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCollectionCrsIdentifierOfStorageCrs">
+        <dct:title>verify Collections Collection Crs Identifier Of Storage Crs </dct:title>
+        <dct:description>Implements A.1 Discovery, Abstract Test 1 (Requirement /req/crs/crs-uri, /req/crs/fc-md-crs-list A, /req/crs/fc-md-storageCrs, /req/crs/fc-md-crs-list-global), storageCrs property in the collection objects in the path /collections</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -651,14 +643,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-253">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.509Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.883Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameterDefault#verifyBboxCrsParameterDefault">
-        <dct:title>verify Bbox Crs Parameter Default </dct:title>
-        <dct:description>Implements A.2.2 Query, Parameter bbox-crs, Abstract Test 10 (Requirement /req/crs/fc-bbox-crs-default-value)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/CrsRequirementClassPrecondition#verifyConformanceClass">
+        <dct:title>verify Conformance Class </dct:title>
+        <dct:description>Precondition: conformance class http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs must be implemented</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -668,11 +660,16 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-132">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.983Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.835Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp">
+        <dct:title>validate Features With Limit Response_ Time Stamp </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 22, Test Method 5 (Requirement /req/core/fc-response) - Abstract Test 24 (Requirement /req/core/fc-timeStamp)</dct:description>
+      </earl:TestCase>
+    </earl:test>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-144">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -680,11 +677,16 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-144">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.672Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.339Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#validateFeatureResponse">
+        <dct:title>validate Feature Response </dct:title>
+        <dct:description>Implements A.2.8. Feature, Abstract Test 28 + 29 (Requirements /req/core/f-success, /req/core/f-links)</dct:description>
+      </earl:TestCase>
+    </earl:test>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-156">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -692,14 +694,14 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-156">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.172Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.442Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84">
-        <dct:title>validate Features With Limit Response_ Geometry In CRS84 </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 2, Test Method 2 (Requirement /req/core/crs84)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned">
+        <dct:title>validate Features Response_ Number Returned </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 22, Test Method 7 (Requirement /req/core/fc-response) - Abstract Test 26 (Requirement /req/core/fc-numberReturned)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -709,16 +711,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-168">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.116Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.286Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_Items">
-        <dct:title>validate Feature Collections Metadata Operation Response_ Items </dct:title>
-        <dct:description>A.2.5. Feature Collections {root}/collections, Abstract Test 10, Test Method 2 (Requirement /req/core/fc-md-success, /req/core/crs84)</dct:description>
-      </earl:TestCase>
-    </earl:test>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-9">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -726,8 +723,8 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-9">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.618Z</dct:date>
-        <dct:description>java.lang.AssertionError: Geometry 'POLYGON ((106.57998579307912 52.79998159444554, 106.53998823448521 52.93999888774037, 107.0800069519353 53.18001007751998, 107.2999935242018 53.37999787048953, 107.59997521365611 53.51998932556822, 108.03994835818912 53.859968573616456, 108.37997928266967 54.25999583598784, 109.05270307824526 55.027597561251326, 109.19346967980832 55.53560272889659, 109.50699059452313 55.73091380474372, 109.92980716353523 55.7129562445223, 109.70000206913326 54.980003567110515, 109.66000451053935 54.71999359803395, 109.47996382043448 54.33999095317566, 109.31997358605884 53.81999685323869, 109.22003136600637 53.619983222052994, 108.99999311730755 53.78002513286093, 108.60001753136845 53.4399942083804, 108.800005324338 53.37999787048953, 108.76000776574409 53.200008856816936, 108.45997439985749 53.14001251892607, 108.17999148970011 52.79998159444554, 107.79996300662566 52.579995022179034, 107.31999230349876 52.42000478780339, 106.64003380740229 52.32001089131862, 106.1000150899522 52.03997630472897, 105.740037062607 51.759993394571595, 105.24001590375084 51.52000804300813, 104.81998986208251 51.46001170511727, 104.30002160036167 51.50000926371118, 103.7600028829116 51.60000316019595, 103.6200114278329 51.73999461527464, 103.85999677939637 51.85998729105637, 104.39996382041414 51.85998729105637, 105.05997521364597 52.0000045843512, 105.4800012553143 52.28001333272471, 105.98002241417046 52.51999868428817, 106.26000532432784 52.619992580772944, 106.57998579307912 52.79998159444554))' outside bounding box: '-1.5000000,50.0000000,1.5000000,53.0000000'.</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.785Z</dct:date>
+        <dct:description>java.lang.AssertionError: Geometry 'POLYGON ((106.57998579307912 52.79998159444554, 106.53998823448521 52.93999888774037, 107.0800069519353 53.18001007751998, 107.2999935242018 53.37999787048953, 107.59997521365611 53.51998932556822, 108.03994835818912 53.859968573616456, 108.37997928266967 54.25999583598784, 109.05270307824526 55.027597561251326, 109.19346967980832 55.53560272889659, 109.50699059452313 55.73091380474372, 109.92980716353523 55.7129562445223, 109.70000206913326 54.980003567110515, 109.66000451053935 54.71999359803395, 109.47996382043448 54.33999095317566, 109.31997358605884 53.81999685323869, 109.22003136600637 53.619983222052994, 108.99999311730755 53.78002513286093, 108.60001753136845 53.4399942083804, 108.800005324338 53.37999787048953, 108.76000776574409 53.200008856816936, 108.45997439985749 53.14001251892607, 108.17999148970011 52.79998159444554, 107.79996300662566 52.579995022179034, 107.31999230349876 52.42000478780339, 106.64003380740229 52.32001089131862, 106.1000150899522 52.03997630472897, 105.740037062607 51.759993394571595, 105.24001590375084 51.52000804300813, 104.81998986208251 51.46001170511727, 104.30002160036167 51.50000926371118, 103.7600028829116 51.60000316019595, 103.6200114278329 51.73999461527464, 103.85999677939637 51.85998729105637, 104.39996382041414 51.85998729105637, 105.05997521364597 52.0000045843512, 105.4800012553143 52.28001333272471, 105.98002241417046 52.51999868428817, 106.26000532432784 52.619992580772944, 106.57998579307912 52.79998159444554))' outside bounding box: '177.0000000,65.0000000,-177.0000000,70.0000000'.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
         <cite:message>
           <http:Request>
@@ -754,11 +751,16 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-120">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.657Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.253Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp">
+        <dct:title>validate Features With Bounding Box Response_ Time Stamp </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 22, Test Method 5 (Requirement /req/core/fc-response) - Abstract Test 24 (Requirement /req/core/fc-timeStamp)</dct:description>
+      </earl:TestCase>
+    </earl:test>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-241">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -766,7 +768,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-241">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.467Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.941Z</dct:date>
         <dct:description>org.testng.SkipException: Collection with id 'lakes' at collections path /collections does not specify a storageCrs</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
@@ -784,7 +786,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-169">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.146Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.536Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
@@ -796,53 +798,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-278">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.456Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsDefaultCrs#verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs">
-        <dct:title>verify Collections Path Collection Crs Property Contains Default Crs </dct:title>
-        <dct:description>Implements A.1 Discovery, Abstract Test 2 (Requirement /req/crs/fc-md-crs-list B), crs property contains default crs in the collection objects in the path /collections</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-266">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-266">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.431Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionCrsUri#verifyCollectionCrsIdentifierOfCrsProperty">
-        <dct:title>verify Collection Crs Identifier Of Crs Property </dct:title>
-        <dct:description>Implements A.1 Discovery, Abstract Test 1 (Requirement /req/crs/crs-uri, /req/crs/fc-md-crs-list A, /req/crs/fc-md-storageCrs, /req/crs/fc-md-crs-list-global), crs property in the collection object in the path /collection</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-254">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-254">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.745Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterTransform#verifyFeatureCrsParameterTransformWithoutCrsParameter"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-242">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-242">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.637Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.168Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
@@ -853,116 +809,42 @@
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
-  <earl:Assertion rdf:about="assert-121">
+  <earl:Assertion rdf:about="assert-266">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
-      <earl:TestResult rdf:about="result-121">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.165Z</dct:date>
+      <earl:TestResult rdf:about="result-266">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.222Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithCrsParameter"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-254">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-254">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.075Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesErrorConditions#validateFeaturesOperation_QueryParamInvalid">
-        <dct:title>validate Features Operation_ Query Param Invalid </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - Error Conditions, Abstract Test 13/20 (Requirement /req/core/query-param-invalid)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameter#verifyFeaturesCrsParameter">
+        <dct:title>verify Features Crs Parameter </dct:title>
+        <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 4 (Requirement /req/crs/fc-crs-definition, /req/crs/fc-crs-valid-value B, /req/crs/ogc-crs-header, /req/crs/ogc-crs-header-value, /req/crs/geojson), Content-Crs header in the path /collections/{collectionId}/items</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
-  <earl:Assertion rdf:about="assert-133">
+  <earl:Assertion rdf:about="assert-242">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
-      <earl:TestResult rdf:about="result-133">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.173Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation">
-        <dct:title>validate Features With Bounding Box Operation </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 13: (Requirement /req/core/fc-op)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-145">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-145">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.351Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TypeProperty"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-157">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-157">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.135Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesOperation">
-        <dct:title>validate Features Operation </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 13 (Requirement /req/core/fc-op)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-230">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-230">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.139Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-7">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-7">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.633Z</dct:date>
-        <dct:description>java.lang.AssertionError: Geometry 'POLYGON ((106.57998579307912 52.79998159444554, 106.53998823448521 52.93999888774037, 107.0800069519353 53.18001007751998, 107.2999935242018 53.37999787048953, 107.59997521365611 53.51998932556822, 108.03994835818912 53.859968573616456, 108.37997928266967 54.25999583598784, 109.05270307824526 55.027597561251326, 109.19346967980832 55.53560272889659, 109.50699059452313 55.73091380474372, 109.92980716353523 55.7129562445223, 109.70000206913326 54.980003567110515, 109.66000451053935 54.71999359803395, 109.47996382043448 54.33999095317566, 109.31997358605884 53.81999685323869, 109.22003136600637 53.619983222052994, 108.99999311730755 53.78002513286093, 108.60001753136845 53.4399942083804, 108.800005324338 53.37999787048953, 108.76000776574409 53.200008856816936, 108.45997439985749 53.14001251892607, 108.17999148970011 52.79998159444554, 107.79996300662566 52.579995022179034, 107.31999230349876 52.42000478780339, 106.64003380740229 52.32001089131862, 106.1000150899522 52.03997630472897, 105.740037062607 51.759993394571595, 105.24001590375084 51.52000804300813, 104.81998986208251 51.46001170511727, 104.30002160036167 51.50000926371118, 103.7600028829116 51.60000316019595, 103.6200114278329 51.73999461527464, 103.85999677939637 51.85998729105637, 104.39996382041414 51.85998729105637, 105.05997521364597 52.0000045843512, 105.4800012553143 52.28001333272471, 105.98002241417046 52.51999868428817, 106.26000532432784 52.619992580772944, 106.57998579307912 52.79998159444554))' outside bounding box: '-180.0000000,-90.0000000,180.0000000,-85.0000000'.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
-        <cite:message>
-          <http:Request>
-            <http:resp>
-              <http:Response>
-                <http:body>
-                  <cnt:ContentAsXML>
-                    <cnt:rest/>
-                  </cnt:ContentAsXML>
-                </http:body>
-              </http:Response>
-            </http:resp>
-            <http:requestURI/>
-            <http:methodName>GET</http:methodName>
-          </http:Request>
-        </cite:message>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-275">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-275">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.573Z</dct:date>
+      <earl:TestResult rdf:about="result-242">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.095Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
@@ -973,449 +855,97 @@
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
-  <earl:Assertion rdf:about="assert-154">
+  <earl:Assertion rdf:about="assert-121">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
-      <earl:TestResult rdf:about="result-154">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.686Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-166">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-166">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.542Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-178">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-178">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.186Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-130">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-130">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.231Z</dct:date>
+      <earl:TestResult rdf:about="result-121">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.315Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched">
-        <dct:title>validate Features With Limit Response_ Number Matched </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 22, Test Method 6 (Requirement /req/core/fc-response) - Abstract Test 25 (Requirement /req/core/fc-numberMatched)</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty">
+        <dct:title>validate Features With Bounding Box Response_ Type Property </dct:title>
+        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 22, Test Method 1 (Requirement /req/core/fc-response)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
-  <earl:Assertion rdf:about="assert-142">
+  <earl:Assertion rdf:about="assert-133">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
-      <earl:TestResult rdf:about="result-142">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.29Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-263">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-263">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.49Z</dct:date>
+      <earl:TestResult rdf:about="result-133">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:35.818Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithoutCrsParameter">
-        <dct:title>verify Features Crs Parameter Transform Without Crs Parameter </dct:title>
-        <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 7 (Requirement /req/crs/crs-action), Geometries in the path /collections/{collectionId}/items</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/landingpage/LandingPage#landingPageValidation">
+        <dct:title>landing Page Validation </dct:title>
+        <dct:description>Implements A.2.2. Landing Page {root}/, Abstract Test 4 (Requirement /req/core/root-success)</dct:description>
       </earl:TestCase>
     </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-251">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-251">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.697Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithCrsParameter"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-276">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-276">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.58Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameterInvalid#verifyBboxCrsParameterInvalid"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-264">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-264">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.422Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/CrsRequirementClassPrecondition#verifyConformanceClass">
-        <dct:title>verify Conformance Class </dct:title>
-        <dct:description>Precondition: conformance class http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs must be implemented</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-143">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-143">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.69Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-155">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-155">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.969Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp">
-        <dct:title>validate Features With Bounding Box Response_ Time Stamp </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 22, Test Method 5 (Requirement /req/core/fc-response) - Abstract Test 24 (Requirement /req/core/fc-timeStamp)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-167">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-167">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.753Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched">
-        <dct:title>validate Features With Bounding Box Response_ Number Matched </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 22, Test Method 6 (Requirement /req/core/fc-response) - Abstract Test 25 (Requirement /req/core/fc-numberMatched)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-179">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-179">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.166Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-8">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-8">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.599Z</dct:date>
-        <dct:description>java.lang.AssertionError: Geometry 'POINT (-75 45)' outside bounding box: '-80.0000000,-5.0000000,-70.0000000,5.0000000'.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
-        <cite:message>
-          <http:Request>
-            <http:resp>
-              <http:Response>
-                <http:body>
-                  <cnt:ContentAsXML>
-                    <cnt:rest/>
-                  </cnt:ContentAsXML>
-                </http:body>
-              </http:Response>
-            </http:resp>
-            <http:requestURI/>
-            <http:methodName>GET</http:methodName>
-          </http:Request>
-        </cite:message>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-131">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-131">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.349Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TimeStamp">
-        <dct:title>validate Features Response_ Time Stamp </dct:title>
-        <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 22, Test Method 5 (Requirement /req/core/fc-response) - Abstract Test 24 (Requirement /req/core/fc-timeStamp)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-252">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-252">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.608Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterDefault#verifyFeaturesCrsParameterDefault"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-240">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-240">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.453Z</dct:date>
-        <dct:description>org.testng.SkipException: Collection with id 'obs' does not specify a storageCrs</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionStorageCrs#verifyCollectionCrsIdentifierOfCrsProperty">
-        <dct:title>verify Collection Crs Identifier Of Crs Property </dct:title>
-        <dct:description>Implements A.1 Discovery, Abstract Test 3 (Requirement /req/crs/fc-md-storageCrs-valid-value), storageCrs property in the collection object in the path /collection</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-61">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-61">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.123Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-85">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-85">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.389Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-73">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-73">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.062Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/apidefinition/ApiDefinition#apiDefinitionValidation">
-        <dct:title>api Definition Validation </dct:title>
-        <dct:description>Implements A.2.3. API Definition Path {root}/api (link), Abstract Test 6 (Requirement /req/core/api-definition-success)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-97">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-97">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.366Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition">
-        <dct:title>limit Parameter Definition </dct:title>
-        <dct:description>A.2.7. Features {root}/collections/{collectionId}/items - Limit, Abstract Test 16: (Requirement /req/core/fc-limit-definition)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-180">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-180">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.167Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-192">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-192">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.955Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-50">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-50">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.79Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-74">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-74">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.36Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#featureOperation">
-        <dct:title>feature Operation </dct:title>
-        <dct:description>Implements A.2.8. Feature, Abstract Test 27 (Requirement /req/core/f-op)</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-62">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-62">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.155Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-98">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-98">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.431Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-86">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-86">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.992Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-181">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-181">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.179Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-193">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-193">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.714Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
   </earl:Assertion>
   <cite:TestRun>
+    <cite:inputs>
+      <rdf:Bag>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>acceptMediaType</dct:title>
+          <dct:description>application/rdf+xml</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>noofcollections</dct:title>
+          <dct:description>-1</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>sourcesId</dct:title>
+          <dct:description>OGC_OGC API-Features 1.0 Conformance Test Suite_1.6</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>iut</dct:title>
+          <dct:description>http://localhost:5000</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>sessionId</dct:title>
+          <dct:description>s0001</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>logDir</dct:title>
+          <dct:description>/usr/local/tomcat/te_base/users/ogctest/rest</dct:description>
+        </rdf:li>
+      </rdf:Bag>
+    </cite:inputs>
+    <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">6</cite:testsSkipped>
+    <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">12</cite:testsFailed>
+    <dct:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#duration">PT9.917S</dct:extent>
+    <cite:testSuiteType>testng</cite:testSuiteType>
+    <dct:identifier>s0001</dct:identifier>
+    <dct:created>2025-03-27T09:43:44.316Z</dct:created>
+    <dct:title>ogcapi-features-1.0-1.6</dct:title>
+    <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">264</cite:testsPassed>
     <cite:requirements>
       <rdf:Seq>
         <rdf:li>
           <earl:TestRequirement rdf:about="Core">
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesErrorConditions#validateFeaturesOperation_QueryParamInvalid"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesErrorConditions#validateFeaturesOperation_QueryParamInvalid">
+                <dct:title>validate Features Operation_ Query Param Invalid </dct:title>
+                <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - Error Conditions, Abstract Test 13/20 (Requirement /req/core/query-param-invalid)</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TypeProperty"/>
             <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty">
-                <dct:title>validate Features With Limit Response_ Type Property </dct:title>
-                <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 22, Test Method 1 (Requirement /req/core/fc-response)</dct:description>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TypeProperty">
+                <dct:title>validate Features Response_ Type Property </dct:title>
+                <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 22, Test Method 1 (Requirement /req/core/fc-response)</dct:description>
               </earl:TestCase>
             </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
             <dct:hasPart>
               <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_CrsProperty">
                 <dct:title>validate Feature Collections Metadata Operation Response_ Crs Property </dct:title>
@@ -1448,9 +978,19 @@
                 <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 22, Test Method 2 (Requirement /req/core/fc-response)</dct:description>
               </earl:TestCase>
             </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84">
+                <dct:title>validate Features With Limit Response_ Geometry In CRS84 </dct:title>
+                <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Limit, Abstract Test 2, Test Method 2 (Requirement /req/core/crs84)</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition">
+                <dct:title>limit Parameter Definition </dct:title>
+                <dct:description>A.2.7. Features {root}/collections/{collectionId}/items - Limit, Abstract Test 16: (Requirement /req/core/fc-limit-definition)</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
             <dct:hasPart>
               <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/landingpage/LandingPage#landingPageRetrieval">
                 <dct:title>landing Page Retrieval </dct:title>
@@ -1458,28 +998,18 @@
               </earl:TestCase>
             </dct:hasPart>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_NumberReturned"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesOperation"/>
-            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">223</cite:testsPassed>
             <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_GeometryInCRS84">
-                <dct:title>validate Features Response_ Geometry In CRS84 </dct:title>
-                <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 2, Test Method 2 (Requirement /req/core/crs84)</dct:description>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesOperation">
+                <dct:title>validate Features Operation </dct:title>
+                <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 13 (Requirement /req/core/fc-op)</dct:description>
               </earl:TestCase>
             </dct:hasPart>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">223</cite:testsPassed>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_GeometryInCRS84"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#validateFeatureResponse">
-                <dct:title>validate Feature Response </dct:title>
-                <dct:description>Implements A.2.8. Feature, Abstract Test 28 + 29 (Requirements /req/core/f-success, /req/core/f-links)</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/landingpage/LandingPage#landingPageValidation">
-                <dct:title>landing Page Validation </dct:title>
-                <dct:description>Implements A.2.2. Landing Page {root}/, Abstract Test 4 (Requirement /req/core/root-success)</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#validateFeatureResponse"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/landingpage/LandingPage#landingPageValidation"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
             <dct:hasPart>
@@ -1488,10 +1018,25 @@
                 <dct:description>Implements A.2.6. Feature Collection {root}/collections/{collectionId}, Abstract Test 11 (Requirement /req/core/sfc-md-op)</dct:description>
               </earl:TestCase>
             </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#featureOperation"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#featureOperation">
+                <dct:title>feature Operation </dct:title>
+                <dct:description>Implements A.2.8. Feature, Abstract Test 27 (Requirement /req/core/f-op)</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_Items"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition">
+                <dct:title>bounding Box Parameter Definition </dct:title>
+                <dct:description>A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 14: (Requirement /req/core/fc-bbox-definition)</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_Items">
+                <dct:title>validate Feature Collections Metadata Operation Response_ Items </dct:title>
+                <dct:description>A.2.5. Feature Collections {root}/collections, Abstract Test 10, Test Method 2 (Requirement /req/core/fc-md-success, /req/core/crs84)</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
             <dct:hasPart>
               <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_Content">
                 <dct:title>validate Feature Collections Metadata Operation Response_ Content </dct:title>
@@ -1512,14 +1057,14 @@
                 <dct:description>Implements A.2.4. Conformance Path {root}/conformance, Abstract Test 7 + 8 (Requirements /req/core/conformance-op and /req/core/conformance-success)</dct:description>
               </earl:TestCase>
             </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_Links"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
             <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_Links">
-                <dct:title>validate Features Response_ Links </dct:title>
-                <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 22, Test Method 4 (Requirement /req/core/fc-response) - Abstract Test 23 (Requirement /req/core/fc-links, /req/core/fc-rel-type)</dct:description>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TimeStamp">
+                <dct:title>validate Features Response_ Time Stamp </dct:title>
+                <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items, Abstract Test 22, Test Method 5 (Requirement /req/core/fc-response) - Abstract Test 24 (Requirement /req/core/fc-timeStamp)</dct:description>
               </earl:TestCase>
             </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TimeStamp"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
             <dct:hasPart>
               <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperation">
@@ -1527,7 +1072,12 @@
                 <dct:description>Implements A.2.5. Feature Collections {root}/collections, Abstract Test 9 (Requirement /req/core/fc-md-op)</dct:description>
               </earl:TestCase>
             </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/apidefinition/ApiDefinition#apiDefinitionValidation"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/apidefinition/ApiDefinition#apiDefinitionValidation">
+                <dct:title>api Definition Validation </dct:title>
+                <dct:description>Implements A.2.3. API Definition Path {root}/api (link), Abstract Test 6 (Requirement /req/core/api-definition-success)</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition"/>
             <dct:hasPart>
               <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesErrorConditions#validateFeaturesOperation_QueryParamUnknown">
@@ -1539,787 +1089,140 @@
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollection#validateFeatureCollectionMetadataResponse"/>
             <cite:isBasic>true</cite:isBasic>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched">
+                <dct:title>validate Features With Bounding Box Response_ Number Matched </dct:title>
+                <dct:description>Implements A.2.7. Features {root}/collections/{collectionId}/items - BoundingBox, Abstract Test 22, Test Method 6 (Requirement /req/core/fc-response) - Abstract Test 25 (Requirement /req/core/fc-numberMatched)</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
             <dct:title>Core</dct:title>
           </earl:TestRequirement>
         </rdf:li>
         <rdf:li>
           <earl:TestRequirement rdf:about="Coordinate-Reference-Systems-by-Reference">
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterTransform#verifyFeatureCrsParameterTransformWithoutCrsParameter"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionStorageCrs#verifyCollectionCrsIdentifierOfCrsProperty"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithoutCrsParameter"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionStorageCrs#verifyCollectionCrsIdentifierOfCrsProperty">
+                <dct:title>verify Collection Crs Identifier Of Crs Property </dct:title>
+                <dct:description>Implements A.1 Discovery, Abstract Test 3 (Requirement /req/crs/fc-md-storageCrs-valid-value), storageCrs property in the collection object in the path /collection</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithoutCrsParameter">
+                <dct:title>verify Features Crs Parameter Transform Without Crs Parameter </dct:title>
+                <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 7 (Requirement /req/crs/crs-action), Geometries in the path /collections/{collectionId}/items</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
             <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">41</cite:testsPassed>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameterWithDefaultCrs"/>
             <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameterWithDefaultCrs">
-                <dct:title>verify Bbox Crs Parameter With Default Crs </dct:title>
-                <dct:description>Implements A.2.2 Query, Parameter bbox-crs, Abstract Test 8 (Requirement /req/crs/fc-bbox-crs-definition, /req/crs/bbox-crs-action)</dct:description>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterDefault#verifyFeaturesCrsParameterDefault">
+                <dct:title>verify Features Crs Parameter Default </dct:title>
+                <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 6 (Requirement /req/crs/fc-crs-default-value, /req/crs/ogc-crs-header, /req/crs/ogc-crs-header-value), Default CRS requesting path /collections/{collectionId}/items</dct:description>
               </earl:TestCase>
             </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterDefault#verifyFeaturesCrsParameterDefault"/>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCollectionCrsIdentifierOfStorageCrs">
-                <dct:title>verify Collections Collection Crs Identifier Of Storage Crs </dct:title>
-                <dct:description>Implements A.1 Discovery, Abstract Test 1 (Requirement /req/crs/crs-uri, /req/crs/fc-md-crs-list A, /req/crs/fc-md-storageCrs, /req/crs/fc-md-crs-list-global), storageCrs property in the collection objects in the path /collections</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCollectionCrsIdentifierOfStorageCrs"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsStorageCrs#verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterInvalid#verifyFeaturesCrsParameterInvalid"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterDefault#verifyFeatureCrsParameterDefault"/>
             <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterTransform#verifyFeatureCrsParameterTransformWithCrsParameter"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameterDefault#verifyBboxCrsParameterDefault"/>
             <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCollectionCrsIdentifierOfCrsProperty">
-                <dct:title>verify Collections Collection Crs Identifier Of Crs Property </dct:title>
-                <dct:description>Implements A.1 Discovery, Abstract Test 1 (Requirement /req/crs/crs-uri, /req/crs/fc-md-crs-list A, /req/crs/fc-md-storageCrs, /req/crs/fc-md-crs-list-global), crs property in the collection objects in the path /collections</dct:description>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameterDefault#verifyBboxCrsParameterDefault">
+                <dct:title>verify Bbox Crs Parameter Default </dct:title>
+                <dct:description>Implements A.2.2 Query, Parameter bbox-crs, Abstract Test 10 (Requirement /req/crs/fc-bbox-crs-default-value)</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterTransform#verifyFeatureCrsParameterTransformWithCrsParameter"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCollectionCrsIdentifierOfCrsProperty"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameter">
+                <dct:title>verify Bbox Crs Parameter </dct:title>
+                <dct:description>Implements A.2.2 Query, Parameter bbox-crs, Abstract Test 8 (Requirement /req/crs/fc-bbox-crs-definition, /req/crs/bbox-crs-action)</dct:description>
               </earl:TestCase>
             </dct:hasPart>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsDefaultCrs#verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameter"/>
             <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">4</cite:testsSkipped>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCrsIdentifierOfCrsProperty"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCrsIdentifierOfStorageCrs"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithCrsParameter"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameter#verifyFeaturesCrsParameter"/>
             <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCrsIdentifierOfStorageCrs">
-                <dct:title>verify Collections Crs Identifier Of Storage Crs </dct:title>
-                <dct:description>Implements A.1 Discovery, Abstract Test 1 (Requirement /req/crs/crs-uri, /req/crs/fc-md-crs-list A, /req/crs/fc-md-storageCrs, /req/crs/fc-md-crs-list-global), storageCrs property in the collections object in the path /collections</dct:description>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterInvalid#verifyFeatureCrsParameterInvalid">
+                <dct:title>verify Feature Crs Parameter Invalid </dct:title>
+                <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 1 (Requirement /req/crs/fc-crs-valid-value), Invalid CRS requesting path /collections/{collectionId}/items/{featureId}</dct:description>
               </earl:TestCase>
             </dct:hasPart>
             <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameter#verifyFeaturesCrsParameter">
-                <dct:title>verify Features Crs Parameter </dct:title>
-                <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 4 (Requirement /req/crs/fc-crs-definition, /req/crs/fc-crs-valid-value B, /req/crs/ogc-crs-header, /req/crs/ogc-crs-header-value, /req/crs/geojson), Content-Crs header in the path /collections/{collectionId}/items</dct:description>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameter#verifyFeatureCrsParameter">
+                <dct:title>verify Feature Crs Parameter </dct:title>
+                <dct:description>Implements A.2.1 Query, Parameter crs, Abstract Test 1 (Requirement /req/crs/fc-crs-definition, /req/crs/fc-crs-valid-value B, /req/crs/ogc-crs-header, /req/crs/ogc-crs-header-value, /req/crs/geojson), Content-Crs header in the path /collections/{collectionId}/items/{featureId}</dct:description>
               </earl:TestCase>
             </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameter#verifyFeatureCrsParameter"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterInvalid#verifyFeatureCrsParameterInvalid"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionCrsUri#verifyCollectionCrsIdentifierOfCrsProperty"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionCrsUri#verifyCollectionCrsIdentifierOfCrsProperty">
+                <dct:title>verify Collection Crs Identifier Of Crs Property </dct:title>
+                <dct:description>Implements A.1 Discovery, Abstract Test 1 (Requirement /req/crs/crs-uri, /req/crs/fc-md-crs-list A, /req/crs/fc-md-storageCrs, /req/crs/fc-md-crs-list-global), crs property in the collection object in the path /collection</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
             <dct:title>Coordinate Reference Systems by Reference</dct:title>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionDefaultCrs#verifyCollectionCrsIdentifierOfCrsProperty"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionDefaultCrs#verifyCollectionCrsIdentifierOfCrsProperty">
+                <dct:title>verify Collection Crs Identifier Of Crs Property </dct:title>
+                <dct:description>Implements A.1 Discovery, Abstract Test 2 (Requirement /req/crs/fc-md-crs-list B), crs property contains default crs in the collection object in the path /collection</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/CrsRequirementClassPrecondition#verifyConformanceClass"/>
             <dct:hasPart rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameterInvalid#verifyBboxCrsParameterInvalid"/>
           </earl:TestRequirement>
         </rdf:li>
       </rdf:Seq>
     </cite:requirements>
-    <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">264</cite:testsPassed>
     <cite:areCoreConformanceClassesPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</cite:areCoreConformanceClassesPassed>
-    <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">6</cite:testsSkipped>
-    <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">12</cite:testsFailed>
-    <dct:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#duration">PT5.97S</dct:extent>
-    <cite:inputs>
-      <rdf:Bag>
-        <rdf:li rdf:parseType="Resource">
-          <dct:title>acceptMediaType</dct:title>
-          <dct:description>application/rdf+xml</dct:description>
-        </rdf:li>
-        <rdf:li rdf:parseType="Resource">
-          <dct:title>noofcollections</dct:title>
-          <dct:description>-1</dct:description>
-        </rdf:li>
-        <rdf:li rdf:parseType="Resource">
-          <dct:title>sourcesId</dct:title>
-          <dct:description>OGC_OGC API-Features 1.0 Conformance Test Suite_1.6</dct:description>
-        </rdf:li>
-        <rdf:li rdf:parseType="Resource">
-          <dct:title>iut</dct:title>
-          <dct:description>http://localhost:5000</dct:description>
-        </rdf:li>
-        <rdf:li rdf:parseType="Resource">
-          <dct:title>sessionId</dct:title>
-          <dct:description>s0007</dct:description>
-        </rdf:li>
-        <rdf:li rdf:parseType="Resource">
-          <dct:title>logDir</dct:title>
-          <dct:description>/usr/local/tomcat/te_base/users/ogctest/rest</dct:description>
-        </rdf:li>
-      </rdf:Bag>
-    </cite:inputs>
-    <cite:testSuiteType>testng</cite:testSuiteType>
-    <dct:title>ogcapi-features-1.0-1.6</dct:title>
-    <dct:identifier>s0007</dct:identifier>
-    <dct:created>2025-03-18T15:46:39.745Z</dct:created>
   </cite:TestRun>
-  <earl:Assertion rdf:about="assert-63">
+  <earl:Assertion rdf:about="assert-145">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
-      <earl:TestResult rdf:about="result-63">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.378Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-51">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-51">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.166Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-87">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-87">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.414Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-75">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-75">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.23Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-99">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-99">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.958Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-190">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-190">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.434Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-52">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-52">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.006Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-40">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-40">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.399Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-76">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-76">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.188Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-64">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-64">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.733Z</dct:date>
+      <earl:TestResult rdf:about="result-145">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.041Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
   </earl:Assertion>
-  <earl:Assertion rdf:about="assert-88">
+  <earl:Assertion rdf:about="assert-157">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
-      <earl:TestResult rdf:about="result-88">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.995Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-191">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-191">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.177Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-92">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-92">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.64Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-80">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-80">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.988Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-93">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-93">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.505Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-172">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-172">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.303Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-281">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-281">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.566Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameter#verifyFeaturesCrsParameter"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-184">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-184">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.365Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#featureOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-196">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-196">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.847Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-160">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-160">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.1Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-81">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-81">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.654Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-94">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-94">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:33.78Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/landingpage/LandingPage#landingPageRetrieval"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-82">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-82">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.179Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-161">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-161">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.439Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-270">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-270">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.477Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithoutCrsParameter"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-173">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-173">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.073Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/conformance/Conformance#validateConformanceOperationAndResponse"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-185">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-185">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.977Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-197">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-197">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.134Z</dct:date>
+      <earl:TestResult rdf:about="result-157">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.517Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
   </earl:Assertion>
-  <earl:Assertion rdf:about="assert-282">
+  <earl:Assertion rdf:about="assert-230">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
-      <earl:TestResult rdf:about="result-282">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.728Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameter"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-70">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-70">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.088Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-83">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-83">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.048Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-71">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-71">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.345Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TimeStamp"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-95">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-95">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.221Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-194">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-194">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.404Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-170">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-170">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.219Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-182">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-182">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.191Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-72">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-72">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.183Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-60">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-60">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.389Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-96">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-96">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.365Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-84">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-84">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.464Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-183">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-183">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.697Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-195">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-195">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.693Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-280">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-280">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.557Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameter#verifyFeaturesCrsParameter"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-171">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-171">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.28Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_GeometryInCRS84"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-229">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-229">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:33.783Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/general/GeneralHttp#http"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-217">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-217">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.762Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-108">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-108">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.366Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-205">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-205">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.683Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-21">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-21">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.181Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-45">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-45">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.195Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-33">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-33">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.384Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-69">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-69">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.972Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-57">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-57">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.158Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollection#validateFeatureCollectionMetadataOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-218">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-218">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.166Z</dct:date>
+      <earl:TestResult rdf:about="result-230">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.949Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
     <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
   </earl:Assertion>
-  <earl:Assertion rdf:about="assert-206">
+  <earl:Assertion rdf:about="assert-7">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
-      <earl:TestResult rdf:about="result-206">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.211Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-109">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-109">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.397Z</dct:date>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-10">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-10">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.431Z</dct:date>
-        <dct:description>java.lang.AssertionError: Required datetime parameter for collections with path '/collections/lakes/items'  in OpenAPI document is missing expected object to not be null</dct:description>
+      <earl:TestResult rdf:about="result-7">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.743Z</dct:date>
+        <dct:description>java.lang.AssertionError: Geometry 'POINT (-75 45)' outside bounding box: '177.0000000,65.0000000,-177.0000000,70.0000000'.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
         <cite:message>
           <http:Request>
@@ -2338,7 +1241,1096 @@
         </cite:message>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-275">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-275">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.298Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterTransform#verifyFeatureCrsParameterTransformWithoutCrsParameter"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-154">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-154">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.73Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-166">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-166">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.946Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesErrorConditions#validateFeaturesOperation_QueryParamInvalid"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-178">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-178">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.835Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-130">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-130">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.949Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-142">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-142">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.885Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-263">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-263">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.178Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterTransform#verifyFeatureCrsParameterTransformWithCrsParameter"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-251">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-251">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.057Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameter#verifyFeatureCrsParameter"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-276">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-276">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.94Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionDefaultCrs#verifyCollectionCrsIdentifierOfCrsProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-264">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-264">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.924Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsDefaultCrs#verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-143">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-143">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.475Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-155">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-155">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.881Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-167">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-167">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.818Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-179">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-179">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.575Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-8">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-8">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.747Z</dct:date>
+        <dct:description>java.lang.AssertionError: Geometry 'POINT (-75 45)' outside bounding box: '-180.0000000,85.0000000,180.0000000,90.0000000'.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest/>
+                  </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI/>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-131">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-131">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.296Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-252">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-252">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.26Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameter"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-240">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-240">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.941Z</dct:date>
+        <dct:description>org.testng.SkipException: Collection with id 'obs' at collections path /collections does not specify a storageCrs</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsStorageCrs#verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-61">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-61">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.456Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-85">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-85">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.31Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TypeProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-73">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-73">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.845Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-97">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-97">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.561Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-180">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-180">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.246Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-192">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-192">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.857Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-50">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-50">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.912Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-74">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-74">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.534Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-62">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-62">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.497Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-98">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-98">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.558Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-86">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-86">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.418Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-181">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-181">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.261Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-193">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-193">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.959Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-63">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-63">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.331Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-51">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-51">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.901Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-87">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-87">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.131Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_FeaturesProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-75">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-75">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.639Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-99">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-99">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.99Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-190">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-190">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.511Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-52">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-52">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.463Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-40">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-40">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.643Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-76">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-76">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.788Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-64">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-64">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.821Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-88">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-88">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.256Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-191">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-191">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.071Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-92">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-92">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.825Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-80">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-80">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.315Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TypeProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-93">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-93">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.332Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-172">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-172">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.793Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-281">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-281">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.019Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameterDefault#verifyBboxCrsParameterDefault"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-184">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-184">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.302Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-196">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-196">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-160">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-160">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.5Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-81">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-81">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.323Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#featureOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-94">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-94">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.95Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-82">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-82">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.29Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-161">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-161">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.158Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_GeometryInCRS84"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-270">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-270">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.086Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameter#verifyFeaturesCrsParameter"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-173">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-173">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.95Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-185">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-185">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.319Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-197">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-197">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.547Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-282">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-282">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.194Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterDefault#verifyFeatureCrsParameterDefault"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-70">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-70">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.683Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-83">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-83">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.854Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-71">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-71">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.457Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/conformance/Conformance#validateConformanceOperationAndResponse"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-95">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-95">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.504Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_Content"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-194">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-194">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.555Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-170">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-170">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.306Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-182">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-182">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.254Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_NumberMatched"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-72">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-72">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.938Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesErrorConditions#validateFeaturesOperation_QueryParamInvalid"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-60">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-60">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.615Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-96">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-96">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.265Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-84">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-84">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.906Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollection#validateFeatureCollectionMetadataOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-183">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-183">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.859Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-195">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-195">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.27Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-280">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-280">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.103Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameterInvalid#verifyBboxCrsParameterInvalid"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-171">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-171">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.344Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-229">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-229">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.93Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-217">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-217">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.738Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-108">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-108">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.841Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-205">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-205">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.331Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-21">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-21">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.826Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-45">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-45">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.609Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-33">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-33">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.006Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-69">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-69">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.403Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-57">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-57">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.906Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-218">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-218">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.451Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-206">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-206">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.349Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-109">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-109">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.354Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-10">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-10">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.735Z</dct:date>
+        <dct:description>java.lang.AssertionError: Geometry 'POINT (-75 45)' outside bounding box: '-1.5000000,50.0000000,1.5000000,53.0000000'.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest/>
+                  </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI/>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-34">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2346,11 +2338,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-34">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.951Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.583Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-22">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2358,11 +2350,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-22">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.096Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.279Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-58">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2370,11 +2362,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-58">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.723Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.24Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-46">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2382,11 +2374,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-46">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.19Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.814Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-239">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2394,12 +2386,12 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-239">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.467Z</dct:date>
-        <dct:description>org.testng.SkipException: Collection with id 'obs' at collections path /collections does not specify a storageCrs</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.921Z</dct:date>
+        <dct:description>org.testng.SkipException: Collection with id 'obs' does not specify a storageCrs</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsStorageCrs#verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionStorageCrs#verifyCollectionCrsIdentifierOfCrsProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-118">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2407,11 +2399,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-118">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.614Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.552Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-106">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2419,11 +2411,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-106">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.259Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.298Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-227">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2431,11 +2423,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-227">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.33Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.863Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-215">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2443,11 +2435,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-215">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.098Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.125Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_Content"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-203">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2455,11 +2447,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-203">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.515Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.299Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-23">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2467,11 +2459,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-23">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.387Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.058Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-11">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2479,8 +2471,8 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-11">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.603Z</dct:date>
-        <dct:description>java.lang.AssertionError: Geometry 'POINT (-75 45)' outside bounding box: '-180.0000000,85.0000000,180.0000000,90.0000000'.</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.773Z</dct:date>
+        <dct:description>java.lang.AssertionError: Geometry 'POLYGON ((106.57998579307912 52.79998159444554, 106.53998823448521 52.93999888774037, 107.0800069519353 53.18001007751998, 107.2999935242018 53.37999787048953, 107.59997521365611 53.51998932556822, 108.03994835818912 53.859968573616456, 108.37997928266967 54.25999583598784, 109.05270307824526 55.027597561251326, 109.19346967980832 55.53560272889659, 109.50699059452313 55.73091380474372, 109.92980716353523 55.7129562445223, 109.70000206913326 54.980003567110515, 109.66000451053935 54.71999359803395, 109.47996382043448 54.33999095317566, 109.31997358605884 53.81999685323869, 109.22003136600637 53.619983222052994, 108.99999311730755 53.78002513286093, 108.60001753136845 53.4399942083804, 108.800005324338 53.37999787048953, 108.76000776574409 53.200008856816936, 108.45997439985749 53.14001251892607, 108.17999148970011 52.79998159444554, 107.79996300662566 52.579995022179034, 107.31999230349876 52.42000478780339, 106.64003380740229 52.32001089131862, 106.1000150899522 52.03997630472897, 105.740037062607 51.759993394571595, 105.24001590375084 51.52000804300813, 104.81998986208251 51.46001170511727, 104.30002160036167 51.50000926371118, 103.7600028829116 51.60000316019595, 103.6200114278329 51.73999461527464, 103.85999677939637 51.85998729105637, 104.39996382041414 51.85998729105637, 105.05997521364597 52.0000045843512, 105.4800012553143 52.28001333272471, 105.98002241417046 52.51999868428817, 106.26000532432784 52.619992580772944, 106.57998579307912 52.79998159444554))' outside bounding box: '-1.5000000,50.0000000,1.5000000,53.0000000'.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
         <cite:message>
           <http:Request>
@@ -2507,11 +2499,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-47">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.126Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.814Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_Links"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-35">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2519,11 +2511,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-35">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.141Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.84Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-59">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2531,11 +2523,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-59">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.644Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.456Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-228">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2543,11 +2535,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-228">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.962Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.121Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-107">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2555,11 +2547,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-107">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.942Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.863Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-119">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2567,11 +2559,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-119">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.446Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.699Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-216">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2579,11 +2571,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-216">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.366Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.527Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-204">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2591,11 +2583,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-204">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.965Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.575Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-12">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2603,7 +2595,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-12">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.432Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.446Z</dct:date>
         <dct:description>java.lang.AssertionError: Required datetime parameter for collections with path '/collections/lakes/items'  in OpenAPI document is missing expected object to not be null</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
         <cite:message>
@@ -2631,11 +2623,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-36">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.153Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.596Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-24">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2643,11 +2635,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-24">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.421Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.877Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-48">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2655,11 +2647,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-48">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.65Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.427Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/apidefinition/ApiDefinition#apiDefinitionValidation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-209">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2667,11 +2659,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-209">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.362Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.445Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-41">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2679,11 +2671,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-41">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.01Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.54Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#validateFeatureResponse"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-65">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2691,11 +2683,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-65">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.249Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.352Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#validateFeatureResponse"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-53">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2703,11 +2695,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-53">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.288Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.481Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_Links"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-89">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2715,11 +2707,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-89">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.367Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.992Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-77">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2727,11 +2719,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-77">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.679Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.978Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-30">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2739,11 +2731,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-30">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.491Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.25Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-54">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2751,11 +2743,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-54">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.46Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.098Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-42">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2763,11 +2755,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-42">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.395Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.331Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-78">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2775,11 +2767,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-78">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.366Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.526Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_Items"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-66">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2787,11 +2779,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-66">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:33.802Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.331Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/apidefinition/ApiDefinition#openapiDocumentRetrieval"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-219">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2799,11 +2791,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-219">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.148Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.622Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-207">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2811,11 +2803,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-207">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.401Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.549Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-43">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2823,11 +2815,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-43">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.157Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.237Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-31">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2835,11 +2827,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-31">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.366Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.472Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-67">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2847,11 +2839,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-67">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.252Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.035Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-55">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2859,11 +2851,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-55">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.974Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.475Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-79">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2871,11 +2863,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-79">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.468Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.89Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-208">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2883,11 +2875,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-208">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.979Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.431Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollection#validateFeatureCollectionMetadataResponse"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-32">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2895,11 +2887,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-32">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.374Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.526Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-20">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2907,11 +2899,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-20">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.945Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.405Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-56">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2919,11 +2911,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-56">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.999Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.567Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-44">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2931,11 +2923,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-44">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.298Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.392Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-68">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2943,11 +2935,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-68">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.949Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.331Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-136">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2955,11 +2947,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-136">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.88Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.811Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-245">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2967,7 +2959,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-245">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.445Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.912Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
@@ -2979,11 +2971,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-233">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.262Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:35.879Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/apidefinition/ApiDefinition#openapiDocumentRetrieval"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-148">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -2991,11 +2983,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-148">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.15Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.162Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesOperation"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-221">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3003,11 +2995,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-221">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.334Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.896Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollection#validateFeatureCollectionMetadataOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-100">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3015,11 +3007,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-100">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.7Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.866Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-269">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3027,11 +3019,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-269">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.467Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.972Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionDefaultCrs#verifyCollectionCrsIdentifierOfCrsProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithoutCrsParameter"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-112">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3039,11 +3031,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-112">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.432Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.95Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-257">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3051,11 +3043,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-257">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.45Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.895Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCrsIdentifierOfStorageCrs"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionCrsUri#verifyCollectionCrsIdentifierOfCrsProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-124">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3063,11 +3055,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-124">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.57Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.515Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_CrsProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-29">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3075,11 +3067,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-29">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.127Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.809Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-17">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3087,11 +3079,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-17">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.125Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.685Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-125">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3099,11 +3091,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-125">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.704Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.86Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-234">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3111,11 +3103,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-234">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.374Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.872Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-137">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3123,11 +3115,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-137">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.151Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.696Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-222">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3135,11 +3127,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-222">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.116Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.881Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-149">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3147,11 +3139,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-149">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:33.786Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.523Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/landingpage/LandingPage#landingPageValidation"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-210">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3159,11 +3151,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-210">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.561Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.479Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-258">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3171,11 +3163,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-258">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.55Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.932Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameter#verifyFeatureCrsParameter"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionDefaultCrs#verifyCollectionCrsIdentifierOfCrsProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-101">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3183,11 +3175,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-101">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.074Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.287Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-113">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3195,11 +3187,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-113">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.432Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.432Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-246">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3207,11 +3199,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-246">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.439Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.066Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCollectionCrsIdentifierOfCrsProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameter#verifyFeatureCrsParameter"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-18">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3219,11 +3211,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-18">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.594Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.33Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#featureOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-158">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3231,11 +3223,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-158">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.081Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.515Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperation"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-267">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3243,11 +3235,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-267">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.585Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.28Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterInvalid#verifyFeatureCrsParameterInvalid"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameter"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-255">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3255,11 +3247,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-255">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.443Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.047Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCollectionCrsIdentifierOfStorageCrs"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameterDefault#verifyBboxCrsParameterDefault"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-243">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3267,11 +3259,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-243">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.644Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.905Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterTransform#verifyFeatureCrsParameterTransformWithCrsParameter"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCollectionCrsIdentifierOfCrsProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-231">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3279,11 +3271,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-231">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.91Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.305Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-110">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3291,11 +3283,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-110">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.817Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.284Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-122">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3303,11 +3295,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-122">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.202Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.088Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-134">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3315,11 +3307,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-134">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.014Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.532Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Feature#validateFeatureResponse"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-146">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3327,11 +3319,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-146">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.482Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.378Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-279">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3339,11 +3331,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-279">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.658Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.895Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterDefault#verifyFeatureCrsParameterDefault"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionCrsUri#verifyCollectionCrsIdentifierOfCrsProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-19">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3351,11 +3343,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-19">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.67Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:35.534Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/general/GeneralHttp#http"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-147">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3363,11 +3355,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-147">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.264Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.366Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-256">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3375,11 +3367,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-256">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.535Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.147Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameterDefault#verifyBboxCrsParameterDefault"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameterWithDefaultCrs"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-159">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3387,11 +3379,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-159">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.473Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.874Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-244">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3399,11 +3391,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-244">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.629Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.119Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameterWithDefaultCrs"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterInvalid#verifyFeatureCrsParameterInvalid"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-232">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3411,11 +3403,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-232">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.37Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.587Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-220">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3423,11 +3415,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-220">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.092Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.851Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-111">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3435,11 +3427,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-111">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.743Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.95Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-123">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3447,11 +3439,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-123">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.647Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.87Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-135">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3459,11 +3451,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-135">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.131Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.327Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-268">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3471,11 +3463,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-268">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.664Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.955Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterInvalid#verifyFeaturesCrsParameterInvalid"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterTransform#verifyFeaturesCrsParameterTransformWithoutCrsParameter"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-1">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3483,8 +3475,8 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-1">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.601Z</dct:date>
-        <dct:description>java.lang.AssertionError: Geometry 'POINT (-75 45)' outside bounding box: '177.0000000,65.0000000,-177.0000000,70.0000000'.</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.751Z</dct:date>
+        <dct:description>java.lang.AssertionError: Geometry 'POINT (-75 45)' outside bounding box: '-180.0000000,-90.0000000,180.0000000,-85.0000000'.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
         <cite:message>
           <http:Request>
@@ -3511,11 +3503,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-201">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.162Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.275Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesErrorConditions#validateFeaturesOperation_QueryParamInvalid"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-104">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3523,11 +3515,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-104">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.111Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.084Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-116">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3535,11 +3527,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-116">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.94Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.817Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-128">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3547,11 +3539,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-128">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.414Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.604Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-249">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3559,11 +3551,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-249">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.456Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.202Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsDefaultCrs#verifyCollectionsPathCollectionCrsPropertyContainsDefaultCrs"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterInvalid#verifyFeaturesCrsParameterInvalid"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-237">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3571,11 +3563,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-237">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.416Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.831Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-225">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3583,11 +3575,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-225">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.274Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.468Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-213">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3595,11 +3587,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-213">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.029Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.845Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-25">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3607,11 +3599,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-25">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.947Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.338Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-13">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3619,8 +3611,8 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-13">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.166Z</dct:date>
-        <dct:description>org.testng.SkipException: Free-form parameters are supported for collection with id obs</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.947Z</dct:date>
+        <dct:description>org.testng.SkipException: Free-form parameters are supported for collection with id lakes</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
@@ -3632,11 +3624,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-49">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.174Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.882Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-37">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3644,11 +3636,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-37">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.154Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.331Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollection#validateFeatureCollectionMetadataOperation"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-2">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3656,8 +3648,8 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-2">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.622Z</dct:date>
-        <dct:description>java.lang.AssertionError: Geometry 'POLYGON ((106.57998579307912 52.79998159444554, 106.53998823448521 52.93999888774037, 107.0800069519353 53.18001007751998, 107.2999935242018 53.37999787048953, 107.59997521365611 53.51998932556822, 108.03994835818912 53.859968573616456, 108.37997928266967 54.25999583598784, 109.05270307824526 55.027597561251326, 109.19346967980832 55.53560272889659, 109.50699059452313 55.73091380474372, 109.92980716353523 55.7129562445223, 109.70000206913326 54.980003567110515, 109.66000451053935 54.71999359803395, 109.47996382043448 54.33999095317566, 109.31997358605884 53.81999685323869, 109.22003136600637 53.619983222052994, 108.99999311730755 53.78002513286093, 108.60001753136845 53.4399942083804, 108.800005324338 53.37999787048953, 108.76000776574409 53.200008856816936, 108.45997439985749 53.14001251892607, 108.17999148970011 52.79998159444554, 107.79996300662566 52.579995022179034, 107.31999230349876 52.42000478780339, 106.64003380740229 52.32001089131862, 106.1000150899522 52.03997630472897, 105.740037062607 51.759993394571595, 105.24001590375084 51.52000804300813, 104.81998986208251 51.46001170511727, 104.30002160036167 51.50000926371118, 103.7600028829116 51.60000316019595, 103.6200114278329 51.73999461527464, 103.85999677939637 51.85998729105637, 104.39996382041414 51.85998729105637, 105.05997521364597 52.0000045843512, 105.4800012553143 52.28001333272471, 105.98002241417046 52.51999868428817, 106.26000532432784 52.619992580772944, 106.57998579307912 52.79998159444554))' outside bounding box: '-80.0000000,-5.0000000,-70.0000000,5.0000000'.</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.79Z</dct:date>
+        <dct:description>java.lang.AssertionError: Geometry 'POLYGON ((106.57998579307912 52.79998159444554, 106.53998823448521 52.93999888774037, 107.0800069519353 53.18001007751998, 107.2999935242018 53.37999787048953, 107.59997521365611 53.51998932556822, 108.03994835818912 53.859968573616456, 108.37997928266967 54.25999583598784, 109.05270307824526 55.027597561251326, 109.19346967980832 55.53560272889659, 109.50699059452313 55.73091380474372, 109.92980716353523 55.7129562445223, 109.70000206913326 54.980003567110515, 109.66000451053935 54.71999359803395, 109.47996382043448 54.33999095317566, 109.31997358605884 53.81999685323869, 109.22003136600637 53.619983222052994, 108.99999311730755 53.78002513286093, 108.60001753136845 53.4399942083804, 108.800005324338 53.37999787048953, 108.76000776574409 53.200008856816936, 108.45997439985749 53.14001251892607, 108.17999148970011 52.79998159444554, 107.79996300662566 52.579995022179034, 107.31999230349876 52.42000478780339, 106.64003380740229 52.32001089131862, 106.1000150899522 52.03997630472897, 105.740037062607 51.759993394571595, 105.24001590375084 51.52000804300813, 104.81998986208251 51.46001170511727, 104.30002160036167 51.50000926371118, 103.7600028829116 51.60000316019595, 103.6200114278329 51.73999461527464, 103.85999677939637 51.85998729105637, 104.39996382041414 51.85998729105637, 105.05997521364597 52.0000045843512, 105.4800012553143 52.28001333272471, 105.98002241417046 52.51999868428817, 106.26000532432784 52.619992580772944, 106.57998579307912 52.79998159444554))' outside bounding box: '-180.0000000,85.0000000,180.0000000,90.0000000'.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
         <cite:message>
           <http:Request>
@@ -3684,11 +3676,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-129">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.105Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.599Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeatureCollections#validateFeatureCollectionsMetadataOperationResponse_CrsProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-105">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3696,11 +3688,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-105">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.642Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.243Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TimeStamp"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-117">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3708,11 +3700,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-117">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.399Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.397Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-238">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3720,7 +3712,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-238">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.455Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.923Z</dct:date>
         <dct:description>org.testng.SkipException: Collection with id 'lakes' does not specify a storageCrs</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
@@ -3733,11 +3725,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-226">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.938Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.207Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-214">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3745,11 +3737,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-214">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.551Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.293Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-202">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3757,11 +3749,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-202">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.27Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.045Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-14">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3769,8 +3761,8 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-14">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.166Z</dct:date>
-        <dct:description>org.testng.SkipException: Free-form parameters are supported for collection with id lakes</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:41.947Z</dct:date>
+        <dct:description>org.testng.SkipException: Free-form parameters are supported for collection with id obs</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
@@ -3782,11 +3774,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-38">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.985Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.606Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-26">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3794,11 +3786,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-26">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.326Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.486Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_NumberMatched"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-114">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3806,11 +3798,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-114">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.533Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.855Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-223">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3818,11 +3810,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-223">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.166Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.657Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#boundingBoxParameterDefinition"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-126">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3830,11 +3822,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-126">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.284Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.487Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_Links"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-211">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3842,11 +3834,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-211">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.409Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.849Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-138">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3854,11 +3846,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-138">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.674Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.11Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-259">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3866,11 +3858,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-259">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.618Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.138Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/bboxcrs/BBoxCrsParameter#verifyBboxCrsParameterWithDefaultCrs"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterDefault#verifyFeaturesCrsParameterDefault"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-247">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3878,11 +3870,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-247">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.431Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.127Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collection/DiscoveryCollectionCrsUri#verifyCollectionCrsIdentifierOfCrsProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/features/FeaturesCrsParameterDefault#verifyFeaturesCrsParameterDefault"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-102">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3890,11 +3882,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-102">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.444Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.715Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-235">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3902,11 +3894,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-235">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.24Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:35.515Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxOperation"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/landingpage/LandingPage#landingPageRetrieval"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-27">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3914,11 +3906,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-27">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.084Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.945Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-15">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3926,11 +3918,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-15">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.635Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.202Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-39">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3938,11 +3930,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-39">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.002Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.385Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitOperation"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-103">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3950,11 +3942,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-103">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.366Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.867Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#limitParameterDefinition"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-212">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3962,11 +3954,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-212">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.681Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.177Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_Links"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_Links"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-115">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3974,11 +3966,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-115">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.166Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.31Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_TypeProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-200">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3986,11 +3978,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-200">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.055Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.589Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-127">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -3998,11 +3990,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-127">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.455Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.143Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/Features#validateFeaturesResponse_FeaturesProperty"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-139">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -4010,11 +4002,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-139">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.66Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.446Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_FeaturesProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-248">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -4022,11 +4014,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-248">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.441Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:44.111Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/discovery/collections/DiscoveryCollectionsCrsUri#verifyCollectionsCollectionCrsIdentifierOfCrsProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/crs/query/crs/feature/FeatureCrsParameterInvalid#verifyFeatureCrsParameterInvalid"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-236">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -4034,11 +4026,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-236">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.404Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:43.546Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_TypeProperty"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-224">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -4046,11 +4038,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-224">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.579Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.446Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_NumberReturned"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesTime#timeParameterDefinition"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-16">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -4058,11 +4050,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-16">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:39.163Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.464Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesLimit#validateFeaturesWithLimitResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-28">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -4070,10 +4062,10 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-28">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T15:46:38.451Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:43:42.975Z</dct:date>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesResponse_GeometryInCRS84"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapifeatures10/conformance/core/collections/FeaturesBBox#validateFeaturesWithBoundingBoxResponse_NumberMatched"/>
   </earl:Assertion>
 </rdf:RDF>

--- a/tests/data/raw-result-ogcapi-processes-1.0-earl.xml
+++ b/tests/data/raw-result-ogcapi-processes-1.0-earl.xml
@@ -12,25 +12,7 @@
     </earl:subject>
     <earl:result>
       <earl:TestResult rdf:about="result-5">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawValueOne">
-        <dct:title>test Job Results Async Raw Value One </dct:title>
-        <dct:description>Implements Requirement /req/core/job-results-async-raw-value-one </dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-21">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-21">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
@@ -42,21 +24,39 @@
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
+  <earl:Assertion rdf:about="assert-21">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-21">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.461Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawRef">
+        <dct:title>test Job Results Async Raw Ref </dct:title>
+        <dct:description>Implements Requirement /req/core/job-results-async-raw-ref </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
   <earl:Assertion rdf:about="assert-45">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-45">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.461Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSuccessAsync">
-        <dct:title>test Job Creation Success Async </dct:title>
-        <dct:description>Implements Requirement /req/core/job-creation-success-async </dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsNoSuchJob">
+        <dct:title>test Job Results No Such Job </dct:title>
+        <dct:description>Implements Requirement /req/core/job-results-exception-no-such-job </dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -66,15 +66,15 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-33">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.554Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.461Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/process/Process#testProcessExceptionNoSuchProcess">
-        <dct:title>test Process Exception No Such Process </dct:title>
-        <dct:description>Implements Requirement /req/core/process-exception-no-such-process </dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/conformance/Conformance#testValidateConformanceOperationAndResponse">
+        <dct:title>test Validate Conformance Operation And Response </dct:title>
+        <dct:description>Implements /conf/core/conformance-success (partial)</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -84,15 +84,15 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-29">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.554Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/process/Process#testProcess">
-        <dct:title>test Process </dct:title>
-        <dct:description>Implements Requirement /req/core/process </dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobExceptionNoSuchJob">
+        <dct:title>test Job Exception No Such Job </dct:title>
+        <dct:description>Implements Requirement /req/core/job-exception-no-such-job </dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -102,25 +102,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-17">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawRef">
-        <dct:title>test Job Creation Sync Raw Ref </dct:title>
-        <dct:description>Implements Requirement /req/core/job-creation-sync-raw-ref </dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-6">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-6">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
@@ -132,21 +114,39 @@
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
+  <earl:Assertion rdf:about="assert-6">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-6">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.461Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawMixedMulti">
+        <dct:title>test Job Results Async Raw Mixed Multi </dct:title>
+        <dct:description>Implements Requirement /req/core/job-results-async-raw-mixed-multi </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
   <earl:Assertion rdf:about="assert-50">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-50">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.557Z</dct:date>
-        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionOutputDef()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@79ca8559] depends on not successfully finished methods</dct:description>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.462Z</dct:date>
+        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionOutputDefinitionOfMixedType()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@57a3d314] depends on not successfully finished methods</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputDef">
-        <dct:title>test O G C Process Description Output Def </dct:title>
-        <dct:description>Implements Requirement /req/ogc-process-description/output-def </dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputDefinitionOfMixedType">
+        <dct:title>test O G C Process Description Output Definition Of Mixed Type </dct:title>
+        <dct:description>Implements Requirement /req/ogc-process-description/output-mixed-type</dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -156,7 +156,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-10">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
@@ -174,15 +174,15 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-34">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.554Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.461Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testProcessListSuccess">
-        <dct:title>test Process List Success </dct:title>
-        <dct:description>Implements Requirement /req/core/process-list-success </dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawValueOne">
+        <dct:title>test Job Results Async Raw Value One </dct:title>
+        <dct:description>Implements Requirement /req/core/job-results-async-raw-value-one </dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
@@ -192,43 +192,7 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-22">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputs">
-        <dct:title>test Job Creation Inputs </dct:title>
-        <dct:description>Implements Requirement /req/core/job-creation-inputs </dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-46">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-46">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.557Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionJSON">
-        <dct:title>test O G C Process Description J S O N </dct:title>
-        <dct:description>Implements Requirement /req/ogc-process-description/json-encoding</dct:description>
-      </earl:TestCase>
-    </earl:test>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-18">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-18">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
@@ -240,13 +204,175 @@
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
+  <earl:Assertion rdf:about="assert-46">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-46">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.462Z</dct:date>
+        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionInputDefinitionOfMixedType()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@57a3d314] depends on not successfully finished methods</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputDefinitionOfMixedType">
+        <dct:title>test O G C Process Description Input Definition Of Mixed Type </dct:title>
+        <dct:description>Implements Requirement /req/ogc-process-description/input-mixed-type</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-18">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-18">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.461Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobSuccess">
+        <dct:title>test Job Success </dct:title>
+        <dct:description>Implements Requirement /req/core/job-success </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
   <earl:Assertion rdf:about="assert-3">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-3">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/process/Process#testProcessExceptionNoSuchProcess">
+        <dct:title>test Process Exception No Such Process </dct:title>
+        <dct:description>Implements Requirement /req/core/process-exception-no-such-process </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-51">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-51">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.462Z</dct:date>
+        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionOutputsDef()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@57a3d314] depends on not successfully finished methods</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputsDef">
+        <dct:title>test O G C Process Description Outputs Def </dct:title>
+        <dct:description>Implements Requirement /req/ogc-process-description/outputs-def</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-23">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-23">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.457Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLimitDefinition">
+        <dct:title>test Pl Limit Definition </dct:title>
+        <dct:description>Implements Requirement /req/core/pl-limit-definition </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-11">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-11">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.458Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage#testLandingPageRetrieval">
+        <dct:title>test Landing Page Retrieval </dct:title>
+        <dct:description>Implements Abstract Test 1: /conf/core/landingpage-op</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-47">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-47">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.462Z</dct:date>
+        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionOutputDef()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@57a3d314] depends on not successfully finished methods</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputDef">
+        <dct:title>test O G C Process Description Output Def </dct:title>
+        <dct:description>Implements Requirement /req/ogc-process-description/output-def </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-35">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-35">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.457Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/general/GeneralHttp#testHttp">
+        <dct:title>test Http </dct:title>
+        <dct:description>Implements A.2.1.1. HTTP, Abstract Test 1 (Requirement /req/core/http)</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-19">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-19">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationRequest">
+        <dct:title>test Job Creation Request </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-request </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-4">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-4">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.461Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
@@ -258,310 +384,568 @@
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
-  <earl:Assertion rdf:about="assert-51">
+  <earl:Assertion rdf:about="assert-52">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
-      <earl:TestResult rdf:about="result-51">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.557Z</dct:date>
-        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionOutputDefinitionOfMixedType()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@79ca8559] depends on not successfully finished methods</dct:description>
+      <earl:TestResult rdf:about="result-52">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.462Z</dct:date>
+        <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
     <earl:test>
-      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputDefinitionOfMixedType">
-        <dct:title>test O G C Process Description Output Definition Of Mixed Type </dct:title>
-        <dct:description>Implements Requirement /req/ogc-process-description/output-mixed-type</dct:description>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionJSON">
+        <dct:title>test O G C Process Description J S O N </dct:title>
+        <dct:description>Implements Requirement /req/ogc-process-description/json-encoding</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-40">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-40">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationDefaultExecutionMode">
+        <dct:title>test Job Creation Default Execution Mode </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-op </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-12">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-12">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationDefaultOutputs">
+        <dct:title>test Job Creation Default Outputs </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-op </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-36">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-36">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineMixed">
+        <dct:title>test Job Creation Input Inline Mixed </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-input-inline-mixed </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-24">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-24">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineObject">
+        <dct:title>test Job Creation Input Inline Object </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-input-inline-object </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-48">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-48">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.462Z</dct:date>
+        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionInputsDef()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@57a3d314] depends on not successfully finished methods</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputsDef">
+        <dct:title>test O G C Process Description Inputs Def </dct:title>
+        <dct:description>Implements Requirement /req/ogc-process-description/inputs-def</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-1">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-1">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobOp">
+        <dct:title>test Job Op </dct:title>
+        <dct:description>Implements Requirement /req/core/job </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-41">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-41">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/process/Process#testProcessSuccess">
+        <dct:title>test Process Success </dct:title>
+        <dct:description>Implements Requirement /req/core/process-success </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-53">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-53">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.462Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/joblist/JobList#testJobListSuccess">
+        <dct:title>test Job List Success </dct:title>
+        <dct:description>Implements Requirement /req/job-list/job-list-success </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-25">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-25">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSuccessAsync">
+        <dct:title>test Job Creation Success Async </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-success-async </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-13">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-13">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawRef">
+        <dct:title>test Job Creation Sync Raw Ref </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-sync-raw-ref </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-9">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-9">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.458Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLimitResponse">
+        <dct:title>test Pl Limit Response </dct:title>
+        <dct:description>Implements Requirement /req/core/pl-limit-response </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-49">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-49">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.462Z</dct:date>
+        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionInputDef()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@57a3d314] depends on not successfully finished methods</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputDef">
+        <dct:title>test O G C Process Description Input Def </dct:title>
+        <dct:description>Implements Requirement /req/ogc-process-description/input-def</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-37">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-37">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputs">
+        <dct:title>test Job Creation Inputs </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-inputs </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-2">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-2">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.461Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawValueMulti">
+        <dct:title>test Job Results Async Raw Value Multi </dct:title>
+        <dct:description>Implements Requirement /req/core/job-results-async-raw-value-multi </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-30">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-30">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.458Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLinks">
+        <dct:title>test Pl Links </dct:title>
+        <dct:description>Implements Requirement /req/core/pl-links </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-54">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-54">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.462Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/joblist/JobList#testJobList">
+        <dct:title>test Job List </dct:title>
+        <dct:description>Implements Requirement /req/job-list/job-list-op </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-42">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-42">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/process/Process#testProcess">
+        <dct:title>test Process </dct:title>
+        <dct:description>Implements Requirement /req/core/process </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-14">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-14">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInline">
+        <dct:title>test Job Creation Input Inline </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-input-inline </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-38">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-38">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.458Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testProcessListSuccess">
+        <dct:title>test Process List Success </dct:title>
+        <dct:description>Implements Requirement /req/core/process-list-success </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-26">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-26">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputValidation">
+        <dct:title>test Job Creation Input Validation </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-input-validation </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-7">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-7">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncDocument">
+        <dct:title>test Job Creation Sync Document </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-sync-document </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-43">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-43">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawValueMulti">
+        <dct:title>test Job Creation Sync Raw Value Multi </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-sync-raw-value-multi </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-31">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-31">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.461Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsSync">
+        <dct:title>test Job Results Sync </dct:title>
+        <dct:description>Implements Requirement /req/core/job-results-sync </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-27">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-27">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.458Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage#testLandingPageValidation">
+        <dct:title>test Landing Page Validation </dct:title>
+        <dct:description>Implements Abstract Test 2: /conf/core/landingpage-success</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-15">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-15">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawValueOne">
+        <dct:title>test Job Creation Sync Raw Value One </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-sync-raw-value-one </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-39">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-39">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.461Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsFailed">
+        <dct:title>test Job Results Failed </dct:title>
+        <dct:description>Implements Requirement /req/core/job-results-failed </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-32">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-32">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationAutoExecutionMode">
+        <dct:title>test Job Creation Auto Execution Mode </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-op </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-20">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-20">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawMixedMulti">
+        <dct:title>test Job Creation Sync Raw Mixed Multi </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-sync-raw-mixed-multi </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-44">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-44">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.458Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testProcessList">
+        <dct:title>test Process List </dct:title>
+        <dct:description>Implements Requirement /req/core/process-list </dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-8">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-8">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.459Z</dct:date>
+        <dct:description>No details available.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputArray">
+        <dct:title>test Job Creation Input Array </dct:title>
+        <dct:description>Implements Requirement /req/core/job-creation-input-array </dct:description>
       </earl:TestCase>
     </earl:test>
   </earl:Assertion>
   <cite:TestRun>
     <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">54</cite:testsSkipped>
-    <dct:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#duration">PT0.01S</dct:extent>
-    <cite:areCoreConformanceClassesPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</cite:areCoreConformanceClassesPassed>
-    <cite:testSuiteType>testng</cite:testSuiteType>
-    <cite:requirements>
-      <rdf:Seq>
-        <rdf:li>
-          <earl:TestRequirement rdf:about="Core">
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsSync">
-                <dct:title>test Job Results Sync </dct:title>
-                <dct:description>Implements Requirement /req/core/job-results-sync </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncDocument"/>
-            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">45</cite:testsSkipped>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineBinary"/>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawMixedMulti">
-                <dct:title>test Job Creation Sync Raw Mixed Multi </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-sync-raw-mixed-multi </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsNoSuchJob">
-                <dct:title>test Job Results No Such Job </dct:title>
-                <dct:description>Implements Requirement /req/core/job-results-exception-no-such-job </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsExceptionResultsNotReady"/>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInline">
-                <dct:title>test Job Creation Input Inline </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-input-inline </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawValueOne">
-                <dct:title>test Job Creation Sync Raw Value One </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-sync-raw-value-one </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobExceptionNoSuchJob">
-                <dct:title>test Job Exception No Such Job </dct:title>
-                <dct:description>Implements Requirement /req/core/job-exception-no-such-job </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputs"/>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputRef">
-                <dct:title>test Job Creation Input Ref </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-input-ref </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationRequest">
-                <dct:title>test Job Creation Request </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-request </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/process/Process#testProcessSuccess">
-                <dct:title>test Process Success </dct:title>
-                <dct:description>Implements Requirement /req/core/process-success </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobOp">
-                <dct:title>test Job Op </dct:title>
-                <dct:description>Implements Requirement /req/core/job </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/process/Process#testProcessExceptionNoSuchProcess"/>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResults">
-                <dct:title>test Job Results </dct:title>
-                <dct:description>Implements Requirement /req/core/job-results </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsFailed">
-                <dct:title>test Job Results Failed </dct:title>
-                <dct:description>Implements Requirement /req/core/job-results-failed </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobSuccess">
-                <dct:title>test Job Success </dct:title>
-                <dct:description>Implements Requirement /req/core/job-success </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testProcessListSuccess"/>
-            <dct:description>A precondition was not met. All tests in this set were skipped.</dct:description>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/process/Process#testProcess"/>
-            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSuccessAsync"/>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputArray">
-                <dct:title>test Job Creation Input Array </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-input-array </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLinks">
-                <dct:title>test Pl Links </dct:title>
-                <dct:description>Implements Requirement /req/core/pl-links </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineMixed">
-                <dct:title>test Job Creation Input Inline Mixed </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-input-inline-mixed </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/conformance/Conformance#testValidateConformanceOperationAndResponse">
-                <dct:title>test Validate Conformance Operation And Response </dct:title>
-                <dct:description>Implements /conf/core/conformance-success (partial)</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationAutoExecutionMode">
-                <dct:title>test Job Creation Auto Execution Mode </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-op </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputValidation">
-                <dct:title>test Job Creation Input Validation </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-input-validation </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationDefaultOutputs">
-                <dct:title>test Job Creation Default Outputs </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-op </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLimitResponse">
-                <dct:title>test Pl Limit Response </dct:title>
-                <dct:description>Implements Requirement /req/core/pl-limit-response </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage#testLandingPageRetrieval">
-                <dct:title>test Landing Page Retrieval </dct:title>
-                <dct:description>Implements Abstract Test 1: /conf/core/landingpage-op</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncDocument">
-                <dct:title>test Job Creation Sync Document </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-sync-document </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawRef">
-                <dct:title>test Job Results Async Raw Ref </dct:title>
-                <dct:description>Implements Requirement /req/core/job-results-async-raw-ref </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineBbox"/>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineObject">
-                <dct:title>test Job Creation Input Inline Object </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-input-inline-object </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testProcessList">
-                <dct:title>test Process List </dct:title>
-                <dct:description>Implements Requirement /req/core/process-list </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/general/GeneralHttp#testHttp">
-                <dct:title>test Http </dct:title>
-                <dct:description>Implements A.2.1.1. HTTP, Abstract Test 1 (Requirement /req/core/http)</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawValueOne"/>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawMixedMulti">
-                <dct:title>test Job Results Async Raw Mixed Multi </dct:title>
-                <dct:description>Implements Requirement /req/core/job-results-async-raw-mixed-multi </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawValueMulti">
-                <dct:title>test Job Results Async Raw Value Multi </dct:title>
-                <dct:description>Implements Requirement /req/core/job-results-async-raw-value-multi </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawValueMulti">
-                <dct:title>test Job Creation Sync Raw Value Multi </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-sync-raw-value-multi </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLimitDefinition">
-                <dct:title>test Pl Limit Definition </dct:title>
-                <dct:description>Implements Requirement /req/core/pl-limit-definition </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawRef"/>
-            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage#testLandingPageValidation">
-                <dct:title>test Landing Page Validation </dct:title>
-                <dct:description>Implements Abstract Test 2: /conf/core/landingpage-success</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationDefaultExecutionMode">
-                <dct:title>test Job Creation Default Execution Mode </dct:title>
-                <dct:description>Implements Requirement /req/core/job-creation-op </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <cite:isBasic>true</cite:isBasic>
-            <dct:title>Core</dct:title>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationOp"/>
-          </earl:TestRequirement>
-        </rdf:li>
-        <rdf:li>
-          <earl:TestRequirement rdf:about="OGC-Process-Description">
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputDefinitionOfMixedType"/>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionJSON"/>
-            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">7</cite:testsSkipped>
-            <dct:title>OGC Process Description</dct:title>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputDefinitionOfMixedType">
-                <dct:title>test O G C Process Description Input Definition Of Mixed Type </dct:title>
-                <dct:description>Implements Requirement /req/ogc-process-description/input-mixed-type</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputsDef">
-                <dct:title>test O G C Process Description Inputs Def </dct:title>
-                <dct:description>Implements Requirement /req/ogc-process-description/inputs-def</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
-            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputDef"/>
-            <dct:description>A precondition was not met. All tests in this set were skipped.</dct:description>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputsDef">
-                <dct:title>test O G C Process Description Outputs Def </dct:title>
-                <dct:description>Implements Requirement /req/ogc-process-description/outputs-def</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputDef">
-                <dct:title>test O G C Process Description Input Def </dct:title>
-                <dct:description>Implements Requirement /req/ogc-process-description/input-def</dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
-          </earl:TestRequirement>
-        </rdf:li>
-        <rdf:li>
-          <earl:TestRequirement rdf:about="Job-List">
-            <dct:title>Job List</dct:title>
-            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
-            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
-            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</cite:testsSkipped>
-            <dct:description>A precondition was not met. All tests in this set were skipped.</dct:description>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/joblist/JobList#testJobListSuccess">
-                <dct:title>test Job List Success </dct:title>
-                <dct:description>Implements Requirement /req/job-list/job-list-success </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-            <dct:hasPart>
-              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/joblist/JobList#testJobList">
-                <dct:title>test Job List </dct:title>
-                <dct:description>Implements Requirement /req/job-list/job-list-op </dct:description>
-              </earl:TestCase>
-            </dct:hasPart>
-          </earl:TestRequirement>
-        </rdf:li>
-      </rdf:Seq>
-    </cite:requirements>
+    <dct:created>2025-03-27T09:44:16.469Z</dct:created>
+    <dct:title>ogcapi-processes-1.0-1.0</dct:title>
     <cite:inputs>
       <rdf:Bag>
         <rdf:li rdf:parseType="Resource">
@@ -582,7 +966,7 @@
         </rdf:li>
         <rdf:li rdf:parseType="Resource">
           <dct:title>sessionId</dct:title>
-          <dct:description>s0008</dct:description>
+          <dct:description>s0002</dct:description>
         </rdf:li>
         <rdf:li rdf:parseType="Resource">
           <dct:title>logDir</dct:title>
@@ -590,505 +974,121 @@
         </rdf:li>
       </rdf:Bag>
     </cite:inputs>
-    <dct:identifier>s0008</dct:identifier>
     <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
-    <dct:title>ogcapi-processes-1.0-1.0</dct:title>
-    <dct:created>2025-03-18T17:07:24.561Z</dct:created>
     <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+    <dct:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#duration">PT0.014S</dct:extent>
+    <cite:requirements>
+      <rdf:Seq>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Core">
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsSync"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncDocument"/>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">45</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineBinary"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawMixedMulti"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsNoSuchJob"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsExceptionResultsNotReady"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInline"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawValueOne"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobExceptionNoSuchJob"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputs"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputRef">
+                <dct:title>test Job Creation Input Ref </dct:title>
+                <dct:description>Implements Requirement /req/core/job-creation-input-ref </dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationRequest"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/process/Process#testProcessSuccess"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobOp"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/process/Process#testProcessExceptionNoSuchProcess"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResults">
+                <dct:title>test Job Results </dct:title>
+                <dct:description>Implements Requirement /req/core/job-results </dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsFailed"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobSuccess"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testProcessListSuccess"/>
+            <dct:description>A precondition was not met. All tests in this set were skipped.</dct:description>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/process/Process#testProcess"/>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSuccessAsync"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputArray"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLinks"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineMixed"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/conformance/Conformance#testValidateConformanceOperationAndResponse"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationAutoExecutionMode"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputValidation"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationDefaultOutputs"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLimitResponse"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage#testLandingPageRetrieval"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncDocument"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawRef"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineBbox"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineObject"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testProcessList"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/general/GeneralHttp#testHttp"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawValueOne"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawMixedMulti"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawValueMulti"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawValueMulti"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLimitDefinition"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawRef"/>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage#testLandingPageValidation"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationDefaultExecutionMode"/>
+            <cite:isBasic>true</cite:isBasic>
+            <dct:title>Core</dct:title>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationOp"/>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="OGC-Process-Description">
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputDefinitionOfMixedType"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionJSON"/>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">7</cite:testsSkipped>
+            <dct:title>OGC Process Description</dct:title>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputDefinitionOfMixedType"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputsDef"/>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputDef"/>
+            <dct:description>A precondition was not met. All tests in this set were skipped.</dct:description>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputsDef"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputDef"/>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Job-List">
+            <dct:title>Job List</dct:title>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</cite:testsSkipped>
+            <dct:description>A precondition was not met. All tests in this set were skipped.</dct:description>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/joblist/JobList#testJobListSuccess"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapiprocesses10/joblist/JobList#testJobList"/>
+          </earl:TestRequirement>
+        </rdf:li>
+      </rdf:Seq>
+    </cite:requirements>
+    <cite:testSuiteType>testng</cite:testSuiteType>
+    <dct:identifier>s0002</dct:identifier>
+    <cite:areCoreConformanceClassesPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</cite:areCoreConformanceClassesPassed>
   </cite:TestRun>
-  <earl:Assertion rdf:about="assert-23">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-23">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/process/Process#testProcessSuccess"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-11">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-11">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawValueOne"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-47">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-47">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.557Z</dct:date>
-        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionInputDef()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@79ca8559] depends on not successfully finished methods</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputDef"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-35">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-35">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationRequest"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-19">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-19">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsSync"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-4">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-4">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.557Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/conformance/Conformance#testValidateConformanceOperationAndResponse"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-52">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-52">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.557Z</dct:date>
-        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionInputDefinitionOfMixedType()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@79ca8559] depends on not successfully finished methods</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputDefinitionOfMixedType"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-40">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-40">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawMixedMulti"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-12">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-12">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.554Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLinks"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-36">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-36">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobOp"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-24">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-24">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncRawValueMulti"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-48">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-48">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.557Z</dct:date>
-        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionInputsDef()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@79ca8559] depends on not successfully finished methods</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionInputsDef"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-1">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-1">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationDefaultOutputs"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-41">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-41">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsNoSuchJob"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-53">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-53">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.557Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/joblist/JobList#testJobListSuccess"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-25">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-25">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputValidation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-13">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-13">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInline"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-9">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-9">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineObject"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-49">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-49">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.557Z</dct:date>
-        <dct:description>java.lang.Throwable: Method OGCProcessDescription.testOGCProcessDescriptionOutputsDef()[pri:0, instance:org.opengis.cite.ogcapiprocesses10.ogcprocessdescription.OGCProcessDescription@79ca8559] depends on not successfully finished methods</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/ogcprocessdescription/OGCProcessDescription#testOGCProcessDescriptionOutputsDef"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-37">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-37">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.554Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testProcessList"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-2">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-2">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationSyncDocument"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-30">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-30">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResults"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-54">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-54">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.557Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/joblist/JobList#testJobList"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-42">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-42">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.554Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage#testLandingPageRetrieval"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-14">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-14">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputInlineMixed"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-38">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-38">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationDefaultExecutionMode"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-26">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-26">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawMixedMulti"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-7">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-7">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputRef"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-43">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-43">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawRef"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-31">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-31">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.554Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/general/GeneralHttp#testHttp"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-27">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-27">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.554Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLimitDefinition"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-15">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-15">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobExceptionNoSuchJob"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-39">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-39">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputArray"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-32">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-32">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsAsyncRawValueMulti"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-20">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-20">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.554Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage#testLandingPageValidation"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-44">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-44">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.555Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationAutoExecutionMode"/>
-  </earl:Assertion>
-  <earl:Assertion rdf:about="assert-8">
-    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
-    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
-    <earl:subject rdf:resource="http://localhost:5000"/>
-    <earl:result>
-      <earl:TestResult rdf:about="result-8">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
-        <dct:description>No details available.</dct:description>
-        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
-      </earl:TestResult>
-    </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobSuccess"/>
-  </earl:Assertion>
   <earl:Assertion rdf:about="assert-16">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
     <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-16">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.556Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResultsFailed"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobResults"/>
   </earl:Assertion>
   <earl:Assertion rdf:about="assert-28">
     <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
@@ -1096,11 +1096,11 @@
     <earl:subject rdf:resource="http://localhost:5000"/>
     <earl:result>
       <earl:TestResult rdf:about="result-28">
-        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-18T17:07:24.554Z</dct:date>
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-27T09:44:16.46Z</dct:date>
         <dct:description>No details available.</dct:description>
         <earl:outcome rdf:resource="http://www.w3.org/ns/earl#untested"/>
       </earl:TestResult>
     </earl:result>
-    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/processlist/ProcessList#testPlLimitResponse"/>
+    <earl:test rdf:resource="org/opengis/cite/ogcapiprocesses10/jobs/Jobs#testJobCreationInputRef"/>
   </earl:Assertion>
 </rdf:RDF>

--- a/tests/test_parsers_earl.py
+++ b/tests/test_parsers_earl.py
@@ -4,9 +4,7 @@ from cite_runner.parsers import earl
 def test_parse_test_suite_result_ogcapi_features_1_0(
     ogcapi_features_1_0_response_element,
 ):
-    response = earl.parse_test_suite_result(
-        ogcapi_features_1_0_response_element, treat_skipped_as_failure=True
-    )
+    response = earl.parse_test_suite_result(ogcapi_features_1_0_response_element)
     assert response.suite_title == "ogcapi-features-1.0-1.6"
     assert response.suite_identifier == "s0007"
     assert response.num_tests_total == 282
@@ -30,16 +28,14 @@ def test_parse_test_suite_result_ogcapi_features_1_0(
 def test_parse_test_suite_result_ogcapi_processes_1_0(
     ogcapi_processes_1_0_response_element,
 ):
-    response = earl.parse_test_suite_result(
-        ogcapi_processes_1_0_response_element, treat_skipped_as_failure=True
-    )
+    response = earl.parse_test_suite_result(ogcapi_processes_1_0_response_element)
     assert response.suite_title == "ogcapi-processes-1.0-1.0"
     assert response.suite_identifier == "s0008"
     assert response.num_tests_total == 54
     assert response.num_failed_tests == 0
     assert response.num_skipped_tests == 54
     assert response.num_passed_tests == 0
-    assert not response.passed
+    assert response.passed
     assert len(response.conformance_class_results) == 3
     core_conf_class = response.conformance_class_results[0]
     assert core_conf_class.title == "Core"

--- a/tests/test_parsers_earl.py
+++ b/tests/test_parsers_earl.py
@@ -6,7 +6,6 @@ def test_parse_test_suite_result_ogcapi_features_1_0(
 ):
     response = earl.parse_test_suite_result(ogcapi_features_1_0_response_element)
     assert response.suite_title == "ogcapi-features-1.0-1.6"
-    assert response.suite_identifier == "s0007"
     assert response.num_tests_total == 282
     assert response.num_failed_tests == 12
     assert response.num_skipped_tests == 6
@@ -30,7 +29,6 @@ def test_parse_test_suite_result_ogcapi_processes_1_0(
 ):
     response = earl.parse_test_suite_result(ogcapi_processes_1_0_response_element)
     assert response.suite_title == "ogcapi-processes-1.0-1.0"
-    assert response.suite_identifier == "s0008"
     assert response.num_tests_total == 54
     assert response.num_failed_tests == 0
     assert response.num_skipped_tests == 54


### PR DESCRIPTION
This PR removes the custom logic that calculated the overall test result in favor of taking it from the teamengine output.

---

- fixes #19