### PR TITLE
Refactored with small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ jobs:
           test_session_arguments: >-
             iut=http://localhost:5001
             noofcollections=-1
-          treat_skipped_tests_as_failures: "true"
 ```
 
 A slightly more complex example, using a matrix to test both `ogcapi-features-1.0`
@@ -162,7 +161,6 @@ jobs:
         with:
           test_suite_identifier: ${{ matrix.test-suite.suite-id }}
           test_session_arguments: ${{ matrix.test-suite.arguments }}
-          treat_skipped_tests_as_failures: "true"
 
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
         raw_result_output_path=raw-result.xml
         poetry run cite-runner \
             --network-timeout=${{ inputs.network_timeout_seconds }} \
-            execute-test-suite \
+            execute-test-suite-from-github-actions \
             ${{ inputs.teamengine_url || 'http://localhost:8080/teamengine' }} \
             ${{ inputs.test_suite_identifier }} \
             --output-format=raw \


### PR DESCRIPTION
- Markdown output format is now the default for all CLI commands
- If the requested output format is `raw`, then we do not attempt to parse the teamengine response
- renamed CLI commands for when running standalone

---

- fixes #14
- fixes #20
- fixes #22