### PR TITLE
Added serialization details

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,18 @@ inputs:
     required: false
     default: 120
     description: Timeout value for network requests
+  include_failed_test_details:
+    required: false
+    default: true
+    description: Whether the output report should include information about failed tests
+  include_skipped_test_details:
+    required: false
+    default: true
+    description: Whether the output report should include information about skipped tests
+  include_passed_test_details:
+    required: false
+    default: false
+    description: Whether the output report should include information about passed tests
 
 outputs:
   results:
@@ -97,6 +109,10 @@ runs:
         poetry run cite-runner \
             parse-result \
             --output-format=markdown \
+            --include-summary \
+            ${{ inputs.include_failed_test_details && '--include-failed-detail \' || '--no-include-failed-detail \'}}
+            ${{ inputs.include_skipped_test_details && '--include-skipped-detail \' || '--no-include-skipped-detail \'}}
+            ${{ inputs.include_passed_test_details && '--include-passed-detail \' || '--no-include-passed-detail \'}}
             ${{ steps.run_executable_test_suite.outputs.RAW_RESULT_OUTPUT_PATH }} 1> ${md_result_output_path}
         echo "MARKDOWN_RESULT_OUTPUT_PATH=${{ github.action_path }}/${md_result_output_path}" >> "${GITHUB_OUTPUT}"
     - name: 'store execution results as artifacts'

--- a/src/cite_runner/models.py
+++ b/src/cite_runner/models.py
@@ -22,6 +22,13 @@ class TestStatus(enum.Enum):
     SKIPPED = "SKIPPED"
 
 
+class SerializationDetails(pydantic.BaseModel):
+    include_summary: bool
+    include_failed_detail: bool
+    include_skipped_detail: bool
+    include_passed_detail: bool
+
+
 class TestSuiteInput(pydantic.BaseModel):
     name: str
     value: str

--- a/src/cite_runner/serializers/simple.py
+++ b/src/cite_runner/serializers/simple.py
@@ -8,15 +8,20 @@ def to_markdown(
     parsed_result: models.TestSuiteResult,
     settings: CiteRunnerSettings,
     jinja_environment: jinja2.Environment,
+    serialization_details: models.SerializationDetails,
 ) -> str:
     """Serialize parsed test suite results to markdown"""
     template = jinja_environment.get_template(settings.simple_serializer_template)
-    return template.render(result=parsed_result)
+    return template.render(
+        result=parsed_result,
+        serialization_details=serialization_details,
+    )
 
 
 def to_json(
     parsed_result: models.TestSuiteResult,
     settings: CiteRunnerSettings,
     jinja_environment: jinja2.Environment,
+    serialization_details: models.SerializationDetails,
 ) -> str:
     return parsed_result.model_dump_json(indent=2)

--- a/src/cite_runner/teamengine_runner.py
+++ b/src/cite_runner/teamengine_runner.py
@@ -29,6 +29,7 @@ class SuiteSerializerProtocol(typing.Protocol):
         suite_result: models.TestSuiteResult,
         settings: config.CiteRunnerSettings,
         jinja_env: jinja2.Environment,
+        serialization_details: models.SerializationDetails,
     ) -> str: ...
 
 
@@ -104,11 +105,12 @@ def serialize_suite_result(
     output_format: models.ParseableOutputFormat,
     settings: config.CiteRunnerSettings,
     jinja_env: jinja2.Environment,
+    serialization_details: models.SerializationDetails,
 ) -> str:
     serializer: SuiteSerializerProtocol = _get_suite_result_serializer(
         output_format, settings, parsed_suite_result.suite_title
     )
-    return serializer(parsed_suite_result, settings, jinja_env)
+    return serializer(parsed_suite_result, settings, jinja_env, serialization_details)
 
 
 def _sanitize_test_suite_identifier(raw_identifier: str) -> str:

--- a/src/cite_runner/templates/test-suite-result.md
+++ b/src/cite_runner/templates/test-suite-result.md
@@ -14,6 +14,7 @@
 - 🟡 Skipped {{ result.num_skipped_tests }} tests
 - 🟢 Passed {{ result.num_passed_tests }} tests
 
+{%- if serialization_details.include_summary %}
 ##### Additional suite details
 
 {%- for input_ in result.inputs %}
@@ -44,7 +45,9 @@
 {%- endfor %}
 </tbody>
 </table>
+{%- endif %}
 
+{%- if serialization_details.include_failed_detail %}
 {%- if result.num_failed_tests > 0 %}
 
 ---
@@ -82,7 +85,9 @@
 {%- endfor %}
 
 {%- endif %}
+{%- endif %}
 
+{%- if serialization_details.include_skipped_detail %}
 {%- if result.num_skipped_tests > 0 %}
 
 ---
@@ -120,7 +125,9 @@
 {%- endfor %}
 
 {%- endif %}
+{%- endif %}
 
+{%- if serialization_details.include_passed_detail %}
 {%- if result.num_passed_tests > 0 %}
 
 ---
@@ -157,4 +164,5 @@
 
 {%- endfor %}
 
+{%- endif %}
 {%- endif %}


### PR DESCRIPTION
It is now possible to ask the output serializer to include/exclude outputting:

- a summary
- details about failed tests
- details about skipped tests
- details about passed tests

The current implementation makes the markdown serializer respect these, but the JSON serializer simply ignores them and always outputs everything.

---

- fixes #1