### PR TITLE
fleshing out standalone section of docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -27,7 +27,7 @@ into an instance of `models.TestSuiteResult`, its internal data structure.From
 there, it is able to serialize it into either JSON or markdown.
 
 
-### Setting up a develoment environment
+### Setting up a development environment
 
 In a brief nutshell:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Key features:
 
 - **Runs as a github action**: Can be integrated into existing CI workflows
 - **Runs as a standalone CLI application**: Can be run as a standalone tool
-- **Multiple output formats**: Can output test suite results as markdown,
+- **Multiple output formats**: Can output test suite results as straight to the terminal in markdown,
   JSON or XML
 
 This project aims to simplify the running of OGC CITE tests suites so that

--- a/src/cite_runner/config.py
+++ b/src/cite_runner/config.py
@@ -73,9 +73,7 @@ def configure_logging(rich_console: Console, debug: bool) -> None:
 
 
 def get_console() -> Console:
-    return Console(
-        stderr=True,
-    )
+    return Console()
 
 
 def get_context(

--- a/src/cite_runner/models.py
+++ b/src/cite_runner/models.py
@@ -11,11 +11,11 @@ class OutputFormat(str, enum.Enum):
     RAW = "raw"
     CONSOLE = "console"
 
-
-class ParseableOutputFormat(str, enum.Enum):
-    JSON = "json"
-    MARKDOWN = "markdown"
-    CONSOLE = "console"
+    def print_pretty(self) -> bool:
+        return {
+            self.JSON: False,
+            self.RAW: False,
+        }.get(self, True)
 
 
 class TestStatus(enum.Enum):

--- a/src/cite_runner/serializers/simple.py
+++ b/src/cite_runner/serializers/simple.py
@@ -24,4 +24,4 @@ def to_json(
     serialization_details: models.SerializationDetails,
     context: config.CiteRunnerContext,
 ) -> str:
-    return parsed_result.model_dump_json(indent=2)
+    return parsed_result.model_dump_json(warnings="error")

--- a/src/cite_runner/teamengine_runner.py
+++ b/src/cite_runner/teamengine_runner.py
@@ -101,7 +101,7 @@ def parse_test_suite_result(
 
 def serialize_suite_result(
     parsed_suite_result: models.TestSuiteResult,
-    output_format: models.ParseableOutputFormat,
+    output_format: models.OutputFormat,
     serialization_details: models.SerializationDetails,
     context: config.CiteRunnerContext,
 ) -> str:
@@ -131,7 +131,7 @@ def _load_python_object(
 
 
 def _get_suite_result_serializer(
-    output_format: models.ParseableOutputFormat,
+    output_format: models.OutputFormat,
     settings: config.CiteRunnerSettings,
     test_suite_identifier: str | None = None,
 ) -> SuiteSerializerProtocol:


### PR DESCRIPTION
This PR adds some content to the docs section about standalone usage.

Also removed the ParseableOutputFormat model