### PR TITLE
Added runtime execution output

### DIFF
--- a/src/cite_runner/config.py
+++ b/src/cite_runner/config.py
@@ -35,7 +35,8 @@ class CiteRunnerContext(pydantic.BaseModel):
     debug: bool = False
     jinja_environment: jinja2.Environment = jinja2.Environment()
     network_timeout_seconds: int = 20
-    rich_console: "Console"
+    result_console: Console
+    status_console: Console
     settings: CiteRunnerSettings
 
 
@@ -72,20 +73,16 @@ def configure_logging(rich_console: Console, debug: bool) -> None:
     logging.getLogger("httpx").setLevel(logging.INFO if debug else logging.WARNING)
 
 
-def get_console() -> Console:
-    return Console()
-
-
 def get_context(
     debug: bool,
     network_timeout_seconds: int,
 ) -> CiteRunnerContext:
     settings = get_settings()
-    console = get_console()
     return CiteRunnerContext(
         debug=debug,
         network_timeout_seconds=network_timeout_seconds,
         jinja_environment=_get_jinja_environment(settings),
         settings=settings,
-        rich_console=console,
+        result_console=Console(),
+        status_console=Console(stderr=True),
     )


### PR DESCRIPTION
This PR adds a secondary rich console for sending status messages to stderr. Main results are still sent to stdout in order to allow piping and redirection. It then adds some light print statements to provide execution feedback to the user

Example:

```shell
$ poetry run cite-runner execute-test-suite \
>     http://localhost:8080/teamengine \
>     ogcapi-features-1.0 \
>     --test-suite-input iut http://localhost:5000 \
>     --output-format json \
> | jq '{result: .passed}'
Checking if teamengine is ready...
Asking teamengine to execute test suite 'ogcapi-features-1.0'...
Received teamengine execution result in EARL format
Parsing test suite execution results...
Serializing parsed results to json...
{
  "result": false
}
```



---

- fixes #10