### PR TITLE
Add an additional step in the github action to show results also in the logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,6 +102,21 @@ runs:
       shell: bash
       run: |
         cd ${{ github.action_path }}
+        echo "::group::Suite execution results"
+        uv run cite-runner \
+            parse-result \
+            --output-format=console \
+            --include-summary \
+            --include-failed-detail \
+            --include-skipped-detail \
+            --include-passed-detail \
+            ${{ steps.run_executable_test_suite.outputs.RAW_RESULT_OUTPUT_PATH }}
+        echo "::endgroup::"
+    - name: 'save execution results'
+      id: 'save_execution_results'
+      shell: bash
+      run: |
+        cd ${{ github.action_path }}
         md_result_output_path=test-result.md
         uv run cite-runner \
             parse-result \
@@ -119,11 +134,11 @@ runs:
         name: 'execution-results-${{ inputs.test_suite_identifier }}'
         path: |
           ${{ steps.run_executable_test_suite.outputs.RAW_RESULT_OUTPUT_PATH }}
-          ${{ steps.parse_execution_results.outputs.MARKDOWN_RESULT_OUTPUT_PATH }}
+          ${{ steps.save_execution_results.outputs.MARKDOWN_RESULT_OUTPUT_PATH }}
     - name: 'Display markdown execution results'
       shell: bash
       run: |
-        cat ${{ steps.parse_execution_results.outputs.MARKDOWN_RESULT_OUTPUT_PATH }} >> ${GITHUB_STEP_SUMMARY}
+        cat ${{ steps.save_execution_results.outputs.MARKDOWN_RESULT_OUTPUT_PATH }} >> ${GITHUB_STEP_SUMMARY}
     - name: 'Stop TEAM engine container'
       if: ${{ !cancelled() && !inputs.teamengine_url }}
       shell: 'bash'


### PR DESCRIPTION
This PR adds an additional step in the github action to parse the execution results with `--output-format=console` and show the suite execution results also in the workflow logs.

---

- fixes #43