### PR TITLE
Control bash execution parameters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ runs:
         echo "RAW_RESULT_OUTPUT_PATH=${{ github.action_path }}/${raw_result_output_path}" >> "${GITHUB_OUTPUT}"
     - name: 'parse execution results'
       id: 'parse_execution_results'
-      shell: bash
+      shell: bash --noprofile --norc -o pipefail {0}
       run: |
         cd ${{ github.action_path }}
         echo "::group::Suite execution results"


### PR DESCRIPTION
This modifies the action code slightly in order to remove the default `-e` parameter when specifying `shell: bash` in a github step. This `-e` flag causes the step to fail immediately if a subcommand fails. More info here:

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell

---

- fixes #53