### PR TITLE
add fourth test execution outcome value

### DIFF
--- a/src/cite_runner/models.py
+++ b/src/cite_runner/models.py
@@ -19,6 +19,7 @@ class OutputFormat(str, enum.Enum):
 
 
 class TestStatus(enum.Enum):
+    CANT_TELL = "CANT_TELL"
     PASSED = "PASSED"
     FAILED = "FAILED"
     SKIPPED = "SKIPPED"
@@ -54,7 +55,7 @@ class ConformanceClassResult(pydantic.BaseModel):
 
     def gen_failed_tests(self) -> Generator[TestCaseResult, None, None]:
         for test_case in self.tests:
-            if test_case.status == TestStatus.FAILED:
+            if test_case.status in (TestStatus.FAILED, TestStatus.CANT_TELL):
                 yield test_case
 
     def gen_skipped_tests(self) -> Generator[TestCaseResult, None, None]:

--- a/src/cite_runner/parsers/earl.py
+++ b/src/cite_runner/parsers/earl.py
@@ -185,7 +185,11 @@ def _parse_assertion(assertion_el: etree.Element, nsmap: dict) -> models.TestCas
         else None
     )
     test_detail = None
-    if test_status in (models.TestStatus.FAILED, models.TestStatus.SKIPPED):
+    if test_status in (
+        models.TestStatus.CANT_TELL,
+        models.TestStatus.FAILED,
+        models.TestStatus.SKIPPED,
+    ):
         test_detail = assertion_el.find(
             "earl:result/earl:TestResult/dct:description", namespaces=nsmap
         ).text

--- a/src/cite_runner/parsers/earl.py
+++ b/src/cite_runner/parsers/earl.py
@@ -149,7 +149,7 @@ def _parse_assertion(assertion_el: etree.Element, nsmap: dict) -> models.TestCas
     ).attrib[f"{{{nsmap['rdf']}}}resource"]
     outcome = raw_outcome.split("earl#")[-1]
     test_status = {
-        "cantTell": models.TestStatus.FAILED,
+        "cantTell": models.TestStatus.CANT_TELL,
         "failed": models.TestStatus.FAILED,
         "inapplicable": models.TestStatus.SKIPPED,
         "passed": models.TestStatus.PASSED,

--- a/src/cite_runner/templates/test-suite-result.md
+++ b/src/cite_runner/templates/test-suite-result.md
@@ -63,15 +63,18 @@
 <table>
   <tr>
     <th>Test case</th>
-{%- if test_case.name %}
-    <td>{{ test_case.name }} ({{ test_case.identifier }})</td>
-{% else %}
-    <td>{{ test_case.identifier }}</td>
-{%- endif %}
+    <td>
+        {%- if test_case.name %}
+            {{ test_case.name }} ({{ test_case.identifier }})
+        {%- else %}
+            {{ test_case.identifier }}
+        {%- endif%}
+        {%- if test_case.description %}<p>{{ test_case.description }}</p>{%- endif %}
+    </td>
   </tr>
   <tr>
-    <th>Description</th>
-    <td>{{ test_case.description | default('-', true) }}</td>
+  <th>Status</th>
+  <td>:red_circle: {{ test_case.status.value }}</td>
   </tr>
   <tr>
     <th>Detail</th>
@@ -103,15 +106,18 @@
 <table>
   <tr>
     <th>Test case</th>
-{%- if test_case.name %}
-    <td>{{ test_case.name }} ({{ test_case.identifier }})</td>
-{% else %}
-    <td>{{ test_case.identifier }}</td>
-{%- endif %}
+    <td>
+        {%- if test_case.name %}
+            {{ test_case.name }} ({{ test_case.identifier }})
+        {%- else %}
+            {{ test_case.identifier }}
+        {%- endif%}
+        {%- if test_case.description %}<p>{{ test_case.description }}</p>{%- endif %}
+    </td>
   </tr>
   <tr>
-    <th>Description</th>
-    <td>{{ test_case.description | default('-', true) }}</td>
+  <th>Status</th>
+  <td>:yellow_circle: {{ test_case.status.value }}</td>
   </tr>
   <tr>
     <th>Detail</th>
@@ -143,19 +149,18 @@
 <table>
   <tr>
     <th>Test case</th>
-{%- if test_case.name %}
-    <td>{{ test_case.name }} ({{ test_case.identifier }})</td>
-{% else %}
-    <td>{{ test_case.identifier }}</td>
-{%- endif %}
+    <td>
+        {%- if test_case.name %}
+            {{ test_case.name }} ({{ test_case.identifier }})
+        {%- else %}
+            {{ test_case.identifier }}
+        {%- endif%}
+        {%- if test_case.description %}<p>{{ test_case.description }}</p>{%- endif %}
+    </td>
   </tr>
   <tr>
-    <th>Description</th>
-    <td>{{ test_case.description | default('-', true) }}</td>
-  </tr>
-  <tr>
-    <th>Detail</th>
-    <td>{{ test_case.detail }}</td>
+  <th>Status</th>
+  <td>:green_circle: {{ test_case.status.value }}</td>
   </tr>
 </table>
 {%- endfor %}

--- a/tests/data/raw-result-csw30.xml
+++ b/tests/data/raw-result-csw30.xml
@@ -1,0 +1,1001 @@
+<?xml version="1.0" encoding="UTF-8"?><rdf:RDF xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:http="http://www.w3.org/2011/http#" xmlns:cnt="http://www.w3.org/2011/content#" xmlns:earl="http://www.w3.org/ns/earl#" xmlns:cite="http://cite.opengeospatial.org/">
+  <earl:Assertion rdf:about="assert-5">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy>
+      <earl:Assertor rdf:about="https://github.com/opengeospatial/teamengine">
+        <dct:title xml:lang="en">OGC TEAM Engine</dct:title>
+        <dct:description xml:lang="en">Official test harness of the OGC conformance testing program (CITE).</dct:description>
+      </earl:Assertor>
+    </earl:assertedBy>
+    <earl:subject>
+      <earl:TestSubject rdf:about="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    </earl:subject>
+    <earl:result>
+      <earl:TestResult rdf:about="result-5">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:43.879Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getRecordsWithUnknownTypeName">
+        <dct:title>get Records With Unknown Type Name </dct:title>
+        <dct:description>Requirements: 088</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-21">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-21">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:32.58Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicSearchTests#getMultipleRecordsById">
+        <dct:title>get Multiple Records By Id </dct:title>
+        <dct:description>OGC 12-176, Table 6 - Record search</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-45">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-45">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:52.948Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchCoreTests#keywordSearch_emptyResultSet">
+        <dct:title>keyword Search_empty Result Set </dct:title>
+        <dct:description>OGC 12-176, Table 6: Text search</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-33">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-33">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:47.308Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetRecordByIdTests#getFullRecordById">
+        <dct:title>get Full Record By Id </dct:title>
+        <dct:description>Requirements: 123</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-29">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-29">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:35.84Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicSearchTests#multipleTermTextSearch">
+        <dct:title>multiple Term Text Search </dct:title>
+        <dct:description>OGC 12-176, Table 6 - Text search</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-17">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-17">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:48.969Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordById_noMatch">
+        <dct:title>get Record By Id_no Match </dct:title>
+        <dct:description>Requirements: 127,141</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-6">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-6">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:33.046Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicSearchTests#getRecordsByBBOXAndTitle">
+        <dct:title>get Records By BBOX And Title </dct:title>
+        <dct:description>Requirements: Table 6</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-50">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-50">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:50.438Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchDescriptionTests#getOpenSearchDescriptionFromCapabilities">
+        <dct:title>get Open Search Description From Capabilities </dct:title>
+        <dct:description>[CAT-HTTP]: 6.5.6.2, Table 16</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-10">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-10">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:45.374Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getSummaryRecordsInAtomFeed">
+        <dct:title>get Summary Records In Atom Feed </dct:title>
+        <dct:description>Requirements: 80,122</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-34">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-34">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:48.147Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordByIdWithMissingId">
+        <dct:title>get Record By Id With Missing Id </dct:title>
+        <dct:description>Requirements: 037</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-22">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-22">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:40.545Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesIsMissingServiceParam">
+        <dct:title>get Capabilities Is Missing Service Param </dct:title>
+        <dct:description>Requirements: 010</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-46">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-46">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:51.132Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchDescriptionTests#validOpenSearchDescription">
+        <dct:title>valid Open Search Description </dct:title>
+        <dct:description>Requirements: 021; Tests: 021</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-18">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-18">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:35.516Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicSearchTests#getSummaryRecordsByWGS84BBOX">
+        <dct:title>get Summary Records By W G S84 BBOX </dct:title>
+        <dct:description>Requirements: 017; Tests: 017</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-3">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-3">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:34.801Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicSearchTests#getRecordsByBBOXWithUnsupportedCRS">
+        <dct:title>get Records By BBOX With Unsupported CRS </dct:title>
+        <dct:description>Requirements: 017</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-51">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-51">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:56.334Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchGeoTests#boundingBoxQuery">
+        <dct:title>bounding Box Query </dct:title>
+        <dct:description>Requirements: 022,023; OGC 10-032r8, A.3</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-23">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-23">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:36.249Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicSearchTests#singleTermTextSearch">
+        <dct:title>single Term Text Search </dct:title>
+        <dct:description>OGC 12-176, Table 6 - Text search</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-11">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-11">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:38.505Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesBySection">
+        <dct:title>get Capabilities By Section </dct:title>
+        <dct:description>Requirements: 044</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-47">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-47">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:56.665Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchGeoTests#getResourceById">
+        <dct:title>get Resource By Id </dct:title>
+        <dct:description>OGC 12-176r6, Table 6</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-35">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-35">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:45.77Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getSummaryRecordsInDefaultRepresentation">
+        <dct:title>get Summary Records In Default Representation </dct:title>
+        <dct:description>Requirements: 101</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-19">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-19">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:38.973Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesFromBaseURL">
+        <dct:title>get Capabilities From Base U R L </dct:title>
+        <dct:description>Requirements: 006</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-4">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-4">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:35.165Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicSearchTests#getRecordsBySubjectWithoutResults">
+        <dct:title>get Records By Subject Without Results </dct:title>
+        <dct:description>Requirements: 086</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-52">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-52">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:57.216Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchGeoTests#getResourceById_notFound">
+        <dct:title>get Resource By Id_not Found </dct:title>
+        <dct:description>Requirement-141</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-40">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-40">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:44.154Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getRecordsWithUnsupportedSchema">
+        <dct:title>get Records With Unsupported Schema </dct:title>
+        <dct:description>Requirements: 035,037,042</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-12">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-12">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:42.86Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getPartialResults">
+        <dct:title>get Partial Results </dct:title>
+        <dct:description>Requirements: 082,084</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-36">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-36">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:48.403Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordByIdWithUnsupportedFormat">
+        <dct:title>get Record By Id With Unsupported Format </dct:title>
+        <dct:description>Requirements: 002,035,128</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-24">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-24">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:39.976Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesInSupportedFormat">
+        <dct:title>get Capabilities In Supported Format </dct:title>
+        <dct:description>Requirements: 036,037,042</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-48">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-48">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:53.975Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchCoreTests#multipleKeywordSearch">
+        <dct:title>multiple Keyword Search </dct:title>
+        <dct:description>OGC 12-176, Table 6: Text search</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-1">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-1">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:48.662Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordByIdWithUnsupportedSchema">
+        <dct:title>get Record By Id With Unsupported Schema </dct:title>
+        <dct:description>Requirements: 132,136</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-41">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-41">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:54.818Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchCoreTests#singleKeywordSearch">
+        <dct:title>single Keyword Search </dct:title>
+        <dct:description>OGC 12-176, Table 6: Text search</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-25">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-25">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:43.604Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getRecordsInUnsupportedOutputFormat">
+        <dct:title>get Records In Unsupported Output Format </dct:title>
+        <dct:description>Requirements: 035,037,042</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-13">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-13">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:46.135Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#presentTitleProperty">
+        <dct:title>present Title Property </dct:title>
+        <dct:description>Requirements: 093</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-9">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-9">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:41.229Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesWithMixedCaseParamNames">
+        <dct:title>get Capabilities With Mixed Case Param Names </dct:title>
+        <dct:description>Requirements: 011</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-49">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-49">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:50.768Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchDescriptionTests#preferOpenSearchDescription">
+        <dct:title>prefer Open Search Description </dct:title>
+        <dct:description>Requirements: 008; Tests: 008</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-37">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-37">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:41.956Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getFullCapabilitiesAcceptVersion3">
+        <dct:title>get Full Capabilities Accept Version3 </dct:title>
+        <dct:description>Requirements: 043,045</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-2">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-2">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:47.023Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetRecordByIdTests#getBriefRecordById">
+        <dct:title>get Brief Record By Id </dct:title>
+        <dct:description>Requirements: 123</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-30">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-30">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:41.522Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesWithUnsupportedVersion">
+        <dct:title>get Capabilities With Unsupported Version </dct:title>
+        <dct:description>Requirements: 036,037,042</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-42">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-42">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:57.842Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchGeoTests#invalidBoundingBoxCoords">
+        <dct:title>invalid Bounding Box Coords </dct:title>
+        <dct:description>OGC 10-032r8: 9.3,A.3</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-14">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-14">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:49.256Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetRecordByIdTests#getSummaryRecordById">
+        <dct:title>get Summary Record By Id </dct:title>
+        <dct:description>Requirements: 124,134</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-38">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-38">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:43.187Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getPartialResultsAsAtomFeed">
+        <dct:title>get Partial Results As Atom Feed </dct:title>
+        <dct:description>Requirements: 082,084,122</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-26">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-26">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:47.578Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordByIdAsAtomEntryUsingAcceptHeader">
+        <dct:title>get Record By Id As Atom Entry Using Accept Header </dct:title>
+        <dct:description>Requirements: 003,139,140</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-7">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-7">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:32.264Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicSearchTests#getBriefRecordsByBBOX">
+        <dct:title>get Brief Records By BBOX </dct:title>
+        <dct:description>Requirements: 017; Tests: 017</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <cite:TestRun>
+    <dct:identifier>s0005</dct:identifier>
+    <cite:areCoreConformanceClassesPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</cite:areCoreConformanceClassesPassed>
+    <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+    <cite:requirements>
+      <rdf:Seq>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Basic-Catalogue">
+            <dct:title>Basic-Catalogue</dct:title>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesInUnsupportedFormat">
+                <dct:title>get Capabilities In Unsupported Format </dct:title>
+                <dct:description>Requirements: 036,037,042</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">40</cite:testsPassed>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesWithUnsupportedVersion"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#elementSetAndElementName">
+                <dct:title>element Set And Element Name </dct:title>
+                <dct:description>Requirements: 099</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordByIdWithUnsupportedSchema"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#presentTitleProperty"/>
+            <cite:isBasic>true</cite:isBasic>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getPartialResults"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordByIdWithUnsupportedFormat"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicSearchTests#textSearchProducesEmptyResultSet">
+                <dct:title>text Search Produces Empty Result Set </dct:title>
+                <dct:description>OGC 12-176, Table 6 - Text search</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordByIdWithMissingId"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordByIdAsAtomEntryUsingAcceptHeader"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicSearchTests#getSummaryRecordsByWGS84BBOX"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordById_noMatch"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordByIdAsAtomEntryUsingOutputFormat">
+                <dct:title>get Record By Id As Atom Entry Using Output Format </dct:title>
+                <dct:description>Requirements: 002,135,140</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesInSupportedFormat"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getPartialResultsAsAtomFeed"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesFromBaseURLAsXML">
+                <dct:title>get Capabilities From Base U R L As XML </dct:title>
+                <dct:description>Requirements: 007</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetRecordByIdTests#getFullRecordById"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetRecordByIdTests#getSummaryRecordById"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#presentUnknownRecordProperty">
+                <dct:title>present Unknown Record Property </dct:title>
+                <dct:description>Requirements: 091</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicSearchTests#getRecordsByBBOXAndTitle"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getRecordsWithUnsupportedSchema"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesFromBaseURL"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getSummaryRecordsInDefaultRepresentation"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicSearchTests#singleTermTextSearch"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getFullCapabilitiesAcceptVersion3"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesBySection"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getSummaryRecordsInAtomFeed"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#unknownElementSetName">
+                <dct:title>unknown Element Set Name </dct:title>
+                <dct:description>Requirements: 102</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getBriefRecordsWithNamespaceBinding">
+                <dct:title>get Brief Records With Namespace Binding </dct:title>
+                <dct:description>Requirements: 063</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesIsMissingServiceParam"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicSearchTests#getRecordsBySubjectWithoutResults"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getRecordsInUnsupportedOutputFormat"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesWithMixedCaseParamNames"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicSearchTests#multipleTermTextSearch"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getRecordsWithUnknownTypeName"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesWithInvalidParamValue">
+                <dct:title>get Capabilities With Invalid Param Value </dct:title>
+                <dct:description>Requirements: 012</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicSearchTests#getMultipleRecordsById"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicSearchTests#getRecordsByBBOXWithUnsupportedCRS"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/GetRecordByIdTests#getBriefRecordById"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/basic/BasicSearchTests#getBriefRecordsByBBOX"/>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="OpenSearch">
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchDescriptionTests#validOpenSearchDescription"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchGeoTests#getResourceById_notFound"/>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">12</cite:testsPassed>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchCoreTests#multipleKeywordSearch"/>
+            <dct:title>OpenSearch</dct:title>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchGeoTests#boundingBoxQuery"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchCoreTests#keywordSearch_emptyResultSet"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchCoreTests#singleKeywordSearch"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchDescriptionTests#preferOpenSearchDescription"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchDescriptionTests#getOpenSearchDescriptionFromCapabilities"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchCoreTests#executeExampleQueries">
+                <dct:title>execute Example Queries </dct:title>
+                <dct:description>OpenSearchDescription: Query element</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/cat30/opensearch/OpenSearchCoreTests#sliceResults">
+                <dct:title>slice Results </dct:title>
+                <dct:description>Requirements: 022,023</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchGeoTests#invalidBoundingBoxCoords"/>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchGeoTests#getResourceById"/>
+          </earl:TestRequirement>
+        </rdf:li>
+      </rdf:Seq>
+    </cite:requirements>
+    <dct:created>2025-04-10T14:17:57.843Z</dct:created>
+    <dct:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#duration">PT26.993S</dct:extent>
+    <cite:testSuiteType>testng</cite:testSuiteType>
+    <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+    <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">52</cite:testsPassed>
+    <dct:title>cat30-1.4</dct:title>
+    <cite:inputs>
+      <rdf:Bag>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>acceptMediaType</dct:title>
+          <dct:description>application/rdf+xml</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>sourcesId</dct:title>
+          <dct:description>OGC_OGC Catalogue 3.0 Conformance Test Suite_1.4</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>iut</dct:title>
+          <dct:description>https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>sessionId</dct:title>
+          <dct:description>s0005</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>logDir</dct:title>
+          <dct:description>/usr/local/tomcat/te_base/users/ogctest/rest</dct:description>
+        </rdf:li>
+      </rdf:Bag>
+    </cite:inputs>
+  </cite:TestRun>
+  <earl:Assertion rdf:about="assert-43">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-43">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:55.45Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchCoreTests#sliceResults"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-31">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-31">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:42.505Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#getBriefRecordsWithNamespaceBinding"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-27">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-27">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:47.842Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/basic/GetRecordByIdTests#getRecordByIdAsAtomEntryUsingOutputFormat"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-15">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-15">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:40.251Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesInUnsupportedFormat"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-39">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-39">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:36.602Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/basic/BasicSearchTests#textSearchProducesEmptyResultSet"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-32">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-32">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:46.435Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#presentUnknownRecordProperty"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-20">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-20">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:42.216Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#elementSetAndElementName"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-44">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-44">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:52.061Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/opensearch/OpenSearchCoreTests#executeExampleQueries"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-8">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-8">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:40.831Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesWithInvalidParamValue"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-16">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-16">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:46.692Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/basic/BasicGetRecordsTests#unknownElementSetName"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-28">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="https://demo.pycsw.org/cite/csw?service=CSW&amp;version=3.0.0&amp;request=GetCapabilities"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-28">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:17:39.396Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/cat30/basic/GetCapabilitiesTests#getCapabilitiesFromBaseURLAsXML"/>
+  </earl:Assertion>
+</rdf:RDF>

--- a/tests/data/raw-result-ogcapi-tiles-1.0-with-cant-tell.xml
+++ b/tests/data/raw-result-ogcapi-tiles-1.0-with-cant-tell.xml
@@ -1,0 +1,508 @@
+<?xml version="1.0" encoding="UTF-8"?><rdf:RDF xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:http="http://www.w3.org/2011/http#" xmlns:cnt="http://www.w3.org/2011/content#" xmlns:earl="http://www.w3.org/ns/earl#" xmlns:cite="http://cite.opengeospatial.org/">
+  <earl:Assertion rdf:about="assert-1">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy>
+      <earl:Assertor rdf:about="https://github.com/opengeospatial/teamengine">
+        <dct:title xml:lang="en">OGC TEAM Engine</dct:title>
+        <dct:description xml:lang="en">Official test harness of the OGC conformance testing program (CITE).</dct:description>
+      </earl:Assertor>
+    </earl:assertedBy>
+    <earl:subject>
+      <earl:TestSubject rdf:about="http://localhost:5000"/>
+    </earl:subject>
+    <earl:result>
+      <earl:TestResult rdf:about="result-1">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:09.439Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/core/MandatoryCore#verifyErrorResponses">
+        <dct:title>verify Error Responses </dct:title>
+        <dct:description>Implements Abstract test A.7, Requirement 6: /req/core/tc-error</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-5">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-5">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:09.591Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileMatrixDefinitionIsAvailable">
+        <dct:title>validate Tile Matrix Definition Is Available </dct:title>
+        <dct:description>Implements Abstract test A.3, Requirement 2: /req/core/tc-tilematrix-definition</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-13">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-13">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:11.246Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/geodatatilesets/GeospatialDataResource#geospatialResourceTilesetsLinksCheck">
+        <dct:title>geospatial Resource Tilesets Links Check </dct:title>
+        <dct:description>Implements Abstract test A.12, addresses Requirement 13</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-9">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-9">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:09.73Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTilesErrorConditions">
+        <dct:title>validate Tiles Error Conditions </dct:title>
+        <dct:description>Implements Abstract test A.7: /conf/core/tc-error, Requirement 6: /req/core/tc-error</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-2">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-2">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:09.441Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/core/MandatoryCore#verifyMinimalConformance">
+        <dct:title>verify Minimal Conformance </dct:title>
+        <dct:description>Implements Abstract test A.6, Requirement 5: /req/core/tc-success</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-6">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-6">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:09.45Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Conformance#validateConformanceOperationAndResponse">
+        <dct:title>validate Conformance Operation And Response </dct:title>
+        <dct:description>Implements Abstract test A.1, Requirement 7: /req/core/conformance-success</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-10">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-10">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:11.146Z</dct:date>
+        <dct:description>java.lang.NullPointerException</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#cantTell"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest/>
+                  </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI/>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/apidefinition/ApiDefinition#apiDefinitionValidation">
+        <dct:title>api Definition Validation </dct:title>
+        <dct:description>Implements Abstract test A.23, Requirement 22: /req/oas30/completeness</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-14">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-14">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:11.296Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/geodatatilesets/GeospatialDataResource#geospatialResourceTilesetsRetrieval">
+        <dct:title>geospatial Resource Tilesets Retrieval </dct:title>
+        <dct:description>Implements Abstract test A.13, addresses Requirement 14</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-3">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-3">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:09.718Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTilesAreAvailable">
+        <dct:title>validate Tiles Are Available </dct:title>
+        <dct:description>Implements Abstract test A.2, Requirement 1: /req/core/tc-op</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-7">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-7">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:09.525Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileColDefinitionIsAvailable">
+        <dct:title>validate Tile Col Definition Is Available </dct:title>
+        <dct:description>Implements Abstract test A.5, Requirement 4: /req/core/tc-tilecol-definition</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-11">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-11">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:11.197Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/tilesetslist/TilesetLlinks#validateTilesetsListResponse">
+        <dct:title>validate Tilesets List Response </dct:title>
+        <dct:description>Implements Abstract test A.9, addresses Requirement 10 (/req/tilesets-list/tileset-links)</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-4">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-4">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:09.649Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileRowDefinitionIsAvailable">
+        <dct:title>validate Tile Row Definition Is Available </dct:title>
+        <dct:description>Implements Abstract test A.4, Requirement 3: /req/core/tc-tilerow-definition</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <cite:TestRun>
+    <dct:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#duration">PT1.864S</dct:extent>
+    <cite:requirements>
+      <rdf:Seq>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Core">
+            <dct:title>Core</dct:title>
+            <cite:isBasic>true</cite:isBasic>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/core/MandatoryCore#verifyErrorResponses"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/core/MandatoryCore#verifyMinimalConformance"/>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Conditional-Core">
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">7</cite:testsPassed>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateSuccessfulTilesExecution">
+                <dct:title>validate Successful Tiles Execution </dct:title>
+                <dct:description>Implements Abstract test A.6, Requirement 5: /req/core/tc-success</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTilesAreAvailable"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTilesErrorConditions"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileRowDefinitionIsAvailable"/>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileMatrixDefinitionIsAvailable"/>
+            <dct:title>Conditional Core</dct:title>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Conformance#validateConformanceOperationAndResponse"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileColDefinitionIsAvailable"/>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="OpenAPI-Specification-3.0">
+            <dct:title>OpenAPI Specification 3.0</dct:title>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/apidefinition/ApiDefinition#apiDefinitionValidation"/>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Tilesets-List">
+            <dct:title>Tilesets List</dct:title>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/tilesetslist/TilesetLlinks#validateTilesetsListResponse"/>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Dataset-Tilesets">
+            <dct:title>Dataset Tilesets</dct:title>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/datasettilesets/LandingPage#landingPageRetrieval">
+                <dct:title>landing Page Retrieval </dct:title>
+                <dct:description>Implements Abstract test A.10, addresses Requirement 11</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="GeoData-Tilesets">
+            <dct:title>GeoData Tilesets</dct:title>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/geodatatilesets/GeospatialDataResource#geospatialResourceTilesetsLinksCheck"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/geodatatilesets/GeospatialDataResource#geospatialResourceTilesetsRetrieval"/>
+          </earl:TestRequirement>
+        </rdf:li>
+      </rdf:Seq>
+    </cite:requirements>
+    <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">12</cite:testsPassed>
+    <dct:identifier>s0021</dct:identifier>
+    <dct:created>2025-03-26T20:56:11.300Z</dct:created>
+    <dct:title>ogcapi-tiles-1.0-1.0</dct:title>
+    <cite:inputs>
+      <rdf:Bag>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>mintilerow</dct:title>
+          <dct:description>0</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>tilematrixsetdefinitionuri</dct:title>
+          <dct:description>http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>iut</dct:title>
+          <dct:description>http://localhost:5000</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>maxtilerow</dct:title>
+          <dct:description>0</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>sessionId</dct:title>
+          <dct:description>s0021</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>maxtilecol</dct:title>
+          <dct:description>0</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>acceptMediaType</dct:title>
+          <dct:description>application/rdf+xml</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>tilematrix</dct:title>
+          <dct:description>0</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>urltemplatefortiles</dct:title>
+          <dct:description>http://localhost:5000/collections/lakes/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>sourcesId</dct:title>
+          <dct:description>OGC_OGC API-tiles 1.0 Conformance Test Suite_1.0</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>mintilecol</dct:title>
+          <dct:description>0</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>logDir</dct:title>
+          <dct:description>/usr/local/tomcat/te_base/users/ogctest/rest</dct:description>
+        </rdf:li>
+      </rdf:Bag>
+    </cite:inputs>
+    <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+    <cite:areCoreConformanceClassesPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</cite:areCoreConformanceClassesPassed>
+    <cite:testSuiteType>testng</cite:testSuiteType>
+    <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</cite:testsFailed>
+  </cite:TestRun>
+  <earl:Assertion rdf:about="assert-12">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-12">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:11.212Z</dct:date>
+        <dct:description>java.lang.AssertionError: Requirement 11 states that if the API has a mechanism for exposing root resources (e.g., a landing page), the API SHALL advertise at least one URI to retrieve a tilesets list provided by this service with a link having a rel value: http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector, http://www.opengis.net/def/rel/ogc/1.0/tilesets-map or http://www.opengis.net/def/rel/ogc/1.0/tilesets-coverage. However, the landing page did not have any such links.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest>HTTP/1.1 200 OK
+Server: Werkzeug/3.0.3 Python/3.11.6
+Date: Wed, 26 Mar 2025 20:56:11 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.20.dev0
+Content-Language: en-US
+Content-Length: 2656
+Connection: close
+
+{
+    "links": [
+        {
+            "rel": "about",
+            "type": "text/html",
+            "title": "pygeoapi default instance",
+            "href": "https://example.org"
+        },
+        {
+            "rel": "self",
+            "type": "application/json",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000?f=json"
+        },
+        {
+            "rel": "alternate",
+            "type": "application/ld+json",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000?f=jsonld"
+        },
+        {
+            "rel": "alternate",
+            "type": "text/html",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "service-desc",
+            "type": "application/vnd.oai.openapi+json;version=3.0",
+            "title": "The OpenAPI definition as JSON",
+            "href": "http://localhost:5000/openapi"
+        },
+        {
+            "rel": "service-doc",
+            "type": "text/html",
+            "title": "The OpenAPI definition as HTML",
+            "href": "http://localhost:5000/openapi?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "conformance",
+            "type": "application/json",
+            "title": "Conformance",
+            "href": "http://localhost:5000/conformance"
+        },
+        {
+            "rel": "data",
+            "type": "application/json",
+            "title": "Collections",
+            "href": "http://localhost:5000/collections"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/processes",
+            "type": "application/json",
+            "title": "Processes",
+            "href": "http://localhost:5000/processes"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/job-list",
+            "type": "application/json",
+            "title": "Jobs",
+            "href": "http://localhost:5000/jobs"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "application/json",
+            "title": "The list of supported tiling schemes as JSON",
+            "href": "http://localhost:5000/TileMatrixSets?f=json"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "text/html",
+            "title": "The list of supported tiling schemes as HTML",
+            "href": "http://localhost:5000/TileMatrixSets?f=html"
+        }
+    ],
+    "title": "pygeoapi default instance",
+    "description": "pygeoapi provides an API to geospatial data"
+}
+</cnt:rest>       </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI>Request method:	GET
+Request URI:	http://localhost:5000/
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+</http:requestURI>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapitiles10/datasettilesets/LandingPage#landingPageRetrieval"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-8">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-8">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-26T20:56:09.464Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateSuccessfulTilesExecution"/>
+  </earl:Assertion>
+</rdf:RDF>

--- a/tests/data/raw-result-ogcapi-tiles-1.0.xml
+++ b/tests/data/raw-result-ogcapi-tiles-1.0.xml
@@ -1,0 +1,5440 @@
+<?xml version="1.0" encoding="UTF-8"?><rdf:RDF xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:http="http://www.w3.org/2011/http#" xmlns:cnt="http://www.w3.org/2011/content#" xmlns:earl="http://www.w3.org/ns/earl#" xmlns:cite="http://cite.opengeospatial.org/">
+  <earl:Assertion rdf:about="assert-1">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy>
+      <earl:Assertor rdf:about="https://github.com/opengeospatial/teamengine">
+        <dct:title xml:lang="en">OGC TEAM Engine</dct:title>
+        <dct:description xml:lang="en">Official test harness of the OGC conformance testing program (CITE).</dct:description>
+      </earl:Assertor>
+    </earl:assertedBy>
+    <earl:subject>
+      <earl:TestSubject rdf:about="http://localhost:5000"/>
+    </earl:subject>
+    <earl:result>
+      <earl:TestResult rdf:about="result-1">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:38.465Z</dct:date>
+        <dct:description>java.lang.AssertionError: Requirement 5A states that a successful execution of the tile operation with content SHALL be reported as a response with an HTTP status code 200. However, the respose code was 400.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest/>
+                  </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI/>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/core/MandatoryCore#verifyMinimalConformance">
+        <dct:title>verify Minimal Conformance </dct:title>
+        <dct:description>Implements Abstract test A.6, Requirement 5: /req/core/tc-success</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-5">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-5">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:38.478Z</dct:date>
+        <dct:description>java.lang.AssertionError: Requirement class "http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core" is not available from path http://localhost:5000/conformance expected [true] but found [false]</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest>HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:38 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 2680
+Connection: close
+
+{
+    "conformsTo": [
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/html",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
+        "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+        "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
+        "http://www.opengis.net/spec/ogcapi-coverages-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-coverages-1/1.0/conf/coverage-bbox",
+        "http://www.opengis.net/spec/ogcapi-coverages-1/1.0/conf/coverage-datetime",
+        "http://www.opengis.net/spec/ogcapi-coverages-1/1.0/conf/coverage-rangesubset",
+        "http://www.opengis.net/spec/ogcapi-coverages-1/1.0/conf/coverage-subset",
+        "http://www.opengis.net/spec/ogcapi-coverages-1/1.0/conf/geodata-coverage",
+        "http://www.opengis.net/spec/ogcapi-coverages-1/1.0/conf/html",
+        "http://www.opengis.net/spec/ogcapi-coverages-1/1.0/conf/oas30",
+        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html",
+        "http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30",
+        "http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs",
+        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables",
+        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables-query-parameters",
+        "http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/create-replace-delete",
+        "http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/schemas",
+        "http://www.opengis.net/spec/ogcapi-features-5/1.0/req/core-roles-features",
+        "http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/callback",
+        "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/json",
+        "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/oas30",
+        "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/ogc-process-description",
+        "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/core",
+        "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/html",
+        "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/json",
+        "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/opensearch",
+        "http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/sorting"
+    ]
+}
+</cnt:rest>       </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI>Request method:	GET
+Request URI:	http://localhost:5000/conformance
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+</http:requestURI>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Conformance#validateConformanceOperationAndResponse">
+        <dct:title>validate Conformance Operation And Response </dct:title>
+        <dct:description>Implements Abstract test A.1, Requirement 7: /req/core/conformance-success</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-13">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-13">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:41.756Z</dct:date>
+        <dct:description>java.lang.AssertionError: Requirement 14 states that the geospatial data resource SHALL have an associated list of at least one tileset accessible at …​/tiles supporting an HTTP GET operation. However, No tilesets link with an href ending with '.../tiles' was found in the geospatial data resources. expected [true] but found [false]</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest>HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:41 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 20893
+Connection: close
+
+{
+    "collections": [
+        {
+            "id": "obs",
+            "title": "Observations",
+            "description": "My cool observations",
+            "keywords": [
+                "observations",
+                "monitoring"
+            ],
+            "links": [
+                {
+                    "type": "text/csv",
+                    "rel": "canonical",
+                    "title": "data",
+                    "href": "https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "text/csv",
+                    "rel": "alternate",
+                    "title": "data",
+                    "href": "https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/obs?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/obs?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/obs?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/obs/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/obs/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/obs/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/obs/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/obs/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2000-10-30T18:24:39+00:00",
+                            "2007-10-30T08:57:29+00:00"
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "lakes",
+            "title": "Large Lakes",
+            "description": "lakes of the world, public domain",
+            "keywords": [
+                "lakes",
+                "water bodies"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "http://www.naturalearthdata.com/",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/lakes?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/lakes?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/lakes/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/lakes/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2011-11-11T11:11:11+00:00",
+                            null
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "mapserver_world_map",
+            "title": "MapServer demo WMS world map",
+            "description": "MapServer demo WMS world map",
+            "keywords": [
+                "MapServer",
+                "world map"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://demo.mapserver.org",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=html"
+                },
+                {
+                    "type": "image/png",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/map",
+                    "title": "Map as png",
+                    "href": "http://localhost:5000/collections/mapserver_world_map/map?f=png"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "gdps-temperature",
+            "title": "Global Deterministic Prediction System sample",
+            "description": "Global Deterministic Prediction System sample",
+            "keywords": [
+                "gdps",
+                "global"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=html"
+                },
+                {
+                    "type": "application/prs.coverage+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=json"
+                },
+                {
+                    "type": "application/x-grib2",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data as GRIB",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=GRIB"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "canada-metadata",
+            "title": "Open Canada sample data",
+            "description": "Sample metadata records from open.canada.ca",
+            "keywords": [
+                "canada",
+                "open data"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://open.canada.ca/en/open-data",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "informations",
+                    "href": "https://ouvert.canada.ca/fr/donnees-ouvertes",
+                    "hreflang": "fr-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            },
+            "itemType": "record"
+        }
+    ],
+    "links": [
+        {
+            "type": "application/json",
+            "rel": "self",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000/collections?f=json"
+        },
+        {
+            "type": "application/ld+json",
+            "rel": "alternate",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000/collections?f=jsonld"
+        },
+        {
+            "type": "text/html",
+            "rel": "alternate",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000/collections?f=html"
+        }
+    ]
+}
+HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:41 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 20893
+Connection: close
+
+{
+    "collections": [
+        {
+            "id": "obs",
+            "title": "Observations",
+            "description": "My cool observations",
+            "keywords": [
+                "observations",
+                "monitoring"
+            ],
+            "links": [
+                {
+                    "type": "text/csv",
+                    "rel": "canonical",
+                    "title": "data",
+                    "href": "https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "text/csv",
+                    "rel": "alternate",
+                    "title": "data",
+                    "href": "https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/obs?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/obs?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/obs?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/obs/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/obs/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/obs/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/obs/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/obs/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2000-10-30T18:24:39+00:00",
+                            "2007-10-30T08:57:29+00:00"
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "lakes",
+            "title": "Large Lakes",
+            "description": "lakes of the world, public domain",
+            "keywords": [
+                "lakes",
+                "water bodies"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "http://www.naturalearthdata.com/",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/lakes?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/lakes?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/lakes/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/lakes/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2011-11-11T11:11:11+00:00",
+                            null
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "mapserver_world_map",
+            "title": "MapServer demo WMS world map",
+            "description": "MapServer demo WMS world map",
+            "keywords": [
+                "MapServer",
+                "world map"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://demo.mapserver.org",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=html"
+                },
+                {
+                    "type": "image/png",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/map",
+                    "title": "Map as png",
+                    "href": "http://localhost:5000/collections/mapserver_world_map/map?f=png"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "gdps-temperature",
+            "title": "Global Deterministic Prediction System sample",
+            "description": "Global Deterministic Prediction System sample",
+            "keywords": [
+                "gdps",
+                "global"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=html"
+                },
+                {
+                    "type": "application/prs.coverage+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=json"
+                },
+                {
+                    "type": "application/x-grib2",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data as GRIB",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=GRIB"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "canada-metadata",
+            "title": "Open Canada sample data",
+            "description": "Sample metadata records from open.canada.ca",
+            "keywords": [
+                "canada",
+                "open data"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://open.canada.ca/en/open-data",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "informations",
+                    "href": "https://ouvert.canada.ca/fr/donnees-ouvertes",
+                    "hreflang": "fr-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            },
+            "itemType": "record"
+        }
+    ],
+    "links": [
+        {
+            "type": "application/json",
+            "rel": "self",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000/collections?f=json"
+        },
+        {
+            "type": "application/ld+json",
+            "rel": "alternate",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000/collections?f=jsonld"
+        },
+        {
+            "type": "text/html",
+            "rel": "alternate",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000/collections?f=html"
+        }
+    ]
+}
+</cnt:rest>       </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI>Request method:	GET
+Request URI:	http://localhost:5000/collections
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+Request method:	GET
+Request URI:	http://localhost:5000/collections
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+</http:requestURI>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/geodatatilesets/GeospatialDataResource#geospatialResourceTilesetsRetrieval">
+        <dct:title>geospatial Resource Tilesets Retrieval </dct:title>
+        <dct:description>Implements Abstract test A.13, addresses Requirement 14</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-9">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-9">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:38.49Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateSuccessfulTilesExecution">
+        <dct:title>validate Successful Tiles Execution </dct:title>
+        <dct:description>Implements Abstract test A.6, Requirement 5: /req/core/tc-success</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-2">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-2">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:38.457Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/core/MandatoryCore#verifyErrorResponses">
+        <dct:title>verify Error Responses </dct:title>
+        <dct:description>Implements Abstract test A.7, Requirement 6: /req/core/tc-error</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-6">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-6">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:38.573Z</dct:date>
+        <dct:description>java.lang.AssertionError: No tiles resource found in collections expected [true] but found [false]</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest>HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:38 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 2656
+Connection: close
+
+{
+    "links": [
+        {
+            "rel": "about",
+            "type": "text/html",
+            "title": "pygeoapi default instance",
+            "href": "https://example.org"
+        },
+        {
+            "rel": "self",
+            "type": "application/json",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000?f=json"
+        },
+        {
+            "rel": "alternate",
+            "type": "application/ld+json",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000?f=jsonld"
+        },
+        {
+            "rel": "alternate",
+            "type": "text/html",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "service-desc",
+            "type": "application/vnd.oai.openapi+json;version=3.0",
+            "title": "The OpenAPI definition as JSON",
+            "href": "http://localhost:5000/openapi"
+        },
+        {
+            "rel": "service-doc",
+            "type": "text/html",
+            "title": "The OpenAPI definition as HTML",
+            "href": "http://localhost:5000/openapi?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "conformance",
+            "type": "application/json",
+            "title": "Conformance",
+            "href": "http://localhost:5000/conformance"
+        },
+        {
+            "rel": "data",
+            "type": "application/json",
+            "title": "Collections",
+            "href": "http://localhost:5000/collections"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/processes",
+            "type": "application/json",
+            "title": "Processes",
+            "href": "http://localhost:5000/processes"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/job-list",
+            "type": "application/json",
+            "title": "Jobs",
+            "href": "http://localhost:5000/jobs"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "application/json",
+            "title": "The list of supported tiling schemes as JSON",
+            "href": "http://localhost:5000/TileMatrixSets?f=json"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "text/html",
+            "title": "The list of supported tiling schemes as HTML",
+            "href": "http://localhost:5000/TileMatrixSets?f=html"
+        }
+    ],
+    "title": "pygeoapi default instance",
+    "description": "pygeoapi provides an API to geospatial data"
+}
+HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:38 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 20893
+Connection: close
+
+{
+    "collections": [
+        {
+            "id": "obs",
+            "title": "Observations",
+            "description": "My cool observations",
+            "keywords": [
+                "observations",
+                "monitoring"
+            ],
+            "links": [
+                {
+                    "type": "text/csv",
+                    "rel": "canonical",
+                    "title": "data",
+                    "href": "https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "text/csv",
+                    "rel": "alternate",
+                    "title": "data",
+                    "href": "https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/obs?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/obs?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/obs?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/obs/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/obs/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/obs/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/obs/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/obs/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2000-10-30T18:24:39+00:00",
+                            "2007-10-30T08:57:29+00:00"
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "lakes",
+            "title": "Large Lakes",
+            "description": "lakes of the world, public domain",
+            "keywords": [
+                "lakes",
+                "water bodies"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "http://www.naturalearthdata.com/",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/lakes?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/lakes?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/lakes/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/lakes/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2011-11-11T11:11:11+00:00",
+                            null
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "mapserver_world_map",
+            "title": "MapServer demo WMS world map",
+            "description": "MapServer demo WMS world map",
+            "keywords": [
+                "MapServer",
+                "world map"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://demo.mapserver.org",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=html"
+                },
+                {
+                    "type": "image/png",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/map",
+                    "title": "Map as png",
+                    "href": "http://localhost:5000/collections/mapserver_world_map/map?f=png"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "gdps-temperature",
+            "title": "Global Deterministic Prediction System sample",
+            "description": "Global Deterministic Prediction System sample",
+            "keywords": [
+                "gdps",
+                "global"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=html"
+                },
+                {
+                    "type": "application/prs.coverage+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=json"
+                },
+                {
+                    "type": "application/x-grib2",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data as GRIB",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=GRIB"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "canada-metadata",
+            "title": "Open Canada sample data",
+            "description": "Sample metadata records from open.canada.ca",
+            "keywords": [
+                "canada",
+                "open data"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://open.canada.ca/en/open-data",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "informations",
+                    "href": "https://ouvert.canada.ca/fr/donnees-ouvertes",
+                    "hreflang": "fr-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            },
+            "itemType": "record"
+        }
+    ],
+    "links": [
+        {
+            "type": "application/json",
+            "rel": "self",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000/collections?f=json"
+        },
+        {
+            "type": "application/ld+json",
+            "rel": "alternate",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000/collections?f=jsonld"
+        },
+        {
+            "type": "text/html",
+            "rel": "alternate",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000/collections?f=html"
+        }
+    ]
+}
+</cnt:rest>       </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI>Request method:	GET
+Request URI:	http://localhost:5000/
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+Request method:	GET
+Request URI:	http://localhost:5000/collections
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+</http:requestURI>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTilesAreAvailable">
+        <dct:title>validate Tiles Are Available </dct:title>
+        <dct:description>Implements Abstract test A.2, Requirement 1: /req/core/tc-op</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-10">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-10">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:41.674Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/apidefinition/ApiDefinition#apiDefinitionValidation">
+        <dct:title>api Definition Validation </dct:title>
+        <dct:description>Implements Abstract test A.23, Requirement 22: /req/oas30/completeness</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-14">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-14">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:41.737Z</dct:date>
+        <dct:description>java.lang.AssertionError: Requirement 13 states that if the Web API based server has a mechanism for geospatial data resources to expose links to geospatial resource aspects (e.g., feature items, metadata…​), the API implementation SHALL include at least one of three link with the href pointing to tilesets list for geospatial data resources and with rel: http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector, http://www.opengis.net/def/rel/ogc/1.0/tilesets-map and http://www.opengis.net/def/rel/ogc/1.0/tilesets-coverage. However, none were found.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest>HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:41 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 20893
+Connection: close
+
+{
+    "collections": [
+        {
+            "id": "obs",
+            "title": "Observations",
+            "description": "My cool observations",
+            "keywords": [
+                "observations",
+                "monitoring"
+            ],
+            "links": [
+                {
+                    "type": "text/csv",
+                    "rel": "canonical",
+                    "title": "data",
+                    "href": "https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "text/csv",
+                    "rel": "alternate",
+                    "title": "data",
+                    "href": "https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/obs?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/obs?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/obs?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/obs/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/obs/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/obs/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/obs/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/obs/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2000-10-30T18:24:39+00:00",
+                            "2007-10-30T08:57:29+00:00"
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "lakes",
+            "title": "Large Lakes",
+            "description": "lakes of the world, public domain",
+            "keywords": [
+                "lakes",
+                "water bodies"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "http://www.naturalearthdata.com/",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/lakes?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/lakes?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/lakes/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/lakes/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2011-11-11T11:11:11+00:00",
+                            null
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "mapserver_world_map",
+            "title": "MapServer demo WMS world map",
+            "description": "MapServer demo WMS world map",
+            "keywords": [
+                "MapServer",
+                "world map"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://demo.mapserver.org",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=html"
+                },
+                {
+                    "type": "image/png",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/map",
+                    "title": "Map as png",
+                    "href": "http://localhost:5000/collections/mapserver_world_map/map?f=png"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "gdps-temperature",
+            "title": "Global Deterministic Prediction System sample",
+            "description": "Global Deterministic Prediction System sample",
+            "keywords": [
+                "gdps",
+                "global"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=html"
+                },
+                {
+                    "type": "application/prs.coverage+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=json"
+                },
+                {
+                    "type": "application/x-grib2",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data as GRIB",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=GRIB"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "canada-metadata",
+            "title": "Open Canada sample data",
+            "description": "Sample metadata records from open.canada.ca",
+            "keywords": [
+                "canada",
+                "open data"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://open.canada.ca/en/open-data",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "informations",
+                    "href": "https://ouvert.canada.ca/fr/donnees-ouvertes",
+                    "hreflang": "fr-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            },
+            "itemType": "record"
+        }
+    ],
+    "links": [
+        {
+            "type": "application/json",
+            "rel": "self",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000/collections?f=json"
+        },
+        {
+            "type": "application/ld+json",
+            "rel": "alternate",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000/collections?f=jsonld"
+        },
+        {
+            "type": "text/html",
+            "rel": "alternate",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000/collections?f=html"
+        }
+    ]
+}
+HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:41 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 20893
+Connection: close
+
+{
+    "collections": [
+        {
+            "id": "obs",
+            "title": "Observations",
+            "description": "My cool observations",
+            "keywords": [
+                "observations",
+                "monitoring"
+            ],
+            "links": [
+                {
+                    "type": "text/csv",
+                    "rel": "canonical",
+                    "title": "data",
+                    "href": "https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "text/csv",
+                    "rel": "alternate",
+                    "title": "data",
+                    "href": "https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/obs?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/obs?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/obs?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/obs/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/obs/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/obs/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/obs/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/obs/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2000-10-30T18:24:39+00:00",
+                            "2007-10-30T08:57:29+00:00"
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "lakes",
+            "title": "Large Lakes",
+            "description": "lakes of the world, public domain",
+            "keywords": [
+                "lakes",
+                "water bodies"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "http://www.naturalearthdata.com/",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/lakes?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/lakes?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/lakes/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/lakes/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2011-11-11T11:11:11+00:00",
+                            null
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "mapserver_world_map",
+            "title": "MapServer demo WMS world map",
+            "description": "MapServer demo WMS world map",
+            "keywords": [
+                "MapServer",
+                "world map"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://demo.mapserver.org",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=html"
+                },
+                {
+                    "type": "image/png",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/map",
+                    "title": "Map as png",
+                    "href": "http://localhost:5000/collections/mapserver_world_map/map?f=png"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "gdps-temperature",
+            "title": "Global Deterministic Prediction System sample",
+            "description": "Global Deterministic Prediction System sample",
+            "keywords": [
+                "gdps",
+                "global"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=html"
+                },
+                {
+                    "type": "application/prs.coverage+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=json"
+                },
+                {
+                    "type": "application/x-grib2",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data as GRIB",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=GRIB"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "canada-metadata",
+            "title": "Open Canada sample data",
+            "description": "Sample metadata records from open.canada.ca",
+            "keywords": [
+                "canada",
+                "open data"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://open.canada.ca/en/open-data",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "informations",
+                    "href": "https://ouvert.canada.ca/fr/donnees-ouvertes",
+                    "hreflang": "fr-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            },
+            "itemType": "record"
+        }
+    ],
+    "links": [
+        {
+            "type": "application/json",
+            "rel": "self",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000/collections?f=json"
+        },
+        {
+            "type": "application/ld+json",
+            "rel": "alternate",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000/collections?f=jsonld"
+        },
+        {
+            "type": "text/html",
+            "rel": "alternate",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000/collections?f=html"
+        }
+    ]
+}
+</cnt:rest>       </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI>Request method:	GET
+Request URI:	http://localhost:5000/collections
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+Request method:	GET
+Request URI:	http://localhost:5000/collections
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+</http:requestURI>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/geodatatilesets/GeospatialDataResource#geospatialResourceTilesetsLinksCheck">
+        <dct:title>geospatial Resource Tilesets Links Check </dct:title>
+        <dct:description>Implements Abstract test A.12, addresses Requirement 13</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-3">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-3">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:38.514Z</dct:date>
+        <dct:description>java.lang.AssertionError: tileCol definition could not be found expected [true] but found [false]</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest>HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:38 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 2656
+Connection: close
+
+{
+    "links": [
+        {
+            "rel": "about",
+            "type": "text/html",
+            "title": "pygeoapi default instance",
+            "href": "https://example.org"
+        },
+        {
+            "rel": "self",
+            "type": "application/json",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000?f=json"
+        },
+        {
+            "rel": "alternate",
+            "type": "application/ld+json",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000?f=jsonld"
+        },
+        {
+            "rel": "alternate",
+            "type": "text/html",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "service-desc",
+            "type": "application/vnd.oai.openapi+json;version=3.0",
+            "title": "The OpenAPI definition as JSON",
+            "href": "http://localhost:5000/openapi"
+        },
+        {
+            "rel": "service-doc",
+            "type": "text/html",
+            "title": "The OpenAPI definition as HTML",
+            "href": "http://localhost:5000/openapi?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "conformance",
+            "type": "application/json",
+            "title": "Conformance",
+            "href": "http://localhost:5000/conformance"
+        },
+        {
+            "rel": "data",
+            "type": "application/json",
+            "title": "Collections",
+            "href": "http://localhost:5000/collections"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/processes",
+            "type": "application/json",
+            "title": "Processes",
+            "href": "http://localhost:5000/processes"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/job-list",
+            "type": "application/json",
+            "title": "Jobs",
+            "href": "http://localhost:5000/jobs"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "application/json",
+            "title": "The list of supported tiling schemes as JSON",
+            "href": "http://localhost:5000/TileMatrixSets?f=json"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "text/html",
+            "title": "The list of supported tiling schemes as HTML",
+            "href": "http://localhost:5000/TileMatrixSets?f=html"
+        }
+    ],
+    "title": "pygeoapi default instance",
+    "description": "pygeoapi provides an API to geospatial data"
+}
+HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:38 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 20893
+Connection: close
+
+{
+    "collections": [
+        {
+            "id": "obs",
+            "title": "Observations",
+            "description": "My cool observations",
+            "keywords": [
+                "observations",
+                "monitoring"
+            ],
+            "links": [
+                {
+                    "type": "text/csv",
+                    "rel": "canonical",
+                    "title": "data",
+                    "href": "https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "text/csv",
+                    "rel": "alternate",
+                    "title": "data",
+                    "href": "https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/obs?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/obs?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/obs?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/obs/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/obs/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/obs/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/obs/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/obs/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2000-10-30T18:24:39+00:00",
+                            "2007-10-30T08:57:29+00:00"
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "lakes",
+            "title": "Large Lakes",
+            "description": "lakes of the world, public domain",
+            "keywords": [
+                "lakes",
+                "water bodies"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "http://www.naturalearthdata.com/",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/lakes?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/lakes?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/lakes/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/lakes/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2011-11-11T11:11:11+00:00",
+                            null
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "mapserver_world_map",
+            "title": "MapServer demo WMS world map",
+            "description": "MapServer demo WMS world map",
+            "keywords": [
+                "MapServer",
+                "world map"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://demo.mapserver.org",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=html"
+                },
+                {
+                    "type": "image/png",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/map",
+                    "title": "Map as png",
+                    "href": "http://localhost:5000/collections/mapserver_world_map/map?f=png"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "gdps-temperature",
+            "title": "Global Deterministic Prediction System sample",
+            "description": "Global Deterministic Prediction System sample",
+            "keywords": [
+                "gdps",
+                "global"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=html"
+                },
+                {
+                    "type": "application/prs.coverage+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=json"
+                },
+                {
+                    "type": "application/x-grib2",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data as GRIB",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=GRIB"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "canada-metadata",
+            "title": "Open Canada sample data",
+            "description": "Sample metadata records from open.canada.ca",
+            "keywords": [
+                "canada",
+                "open data"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://open.canada.ca/en/open-data",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "informations",
+                    "href": "https://ouvert.canada.ca/fr/donnees-ouvertes",
+                    "hreflang": "fr-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            },
+            "itemType": "record"
+        }
+    ],
+    "links": [
+        {
+            "type": "application/json",
+            "rel": "self",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000/collections?f=json"
+        },
+        {
+            "type": "application/ld+json",
+            "rel": "alternate",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000/collections?f=jsonld"
+        },
+        {
+            "type": "text/html",
+            "rel": "alternate",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000/collections?f=html"
+        }
+    ]
+}
+</cnt:rest>       </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI>Request method:	GET
+Request URI:	http://localhost:5000/
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+Request method:	GET
+Request URI:	http://localhost:5000/collections
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+</http:requestURI>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileColDefinitionIsAvailable">
+        <dct:title>validate Tile Col Definition Is Available </dct:title>
+        <dct:description>Implements Abstract test A.5, Requirement 4: /req/core/tc-tilecol-definition</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-7">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-7">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:38.538Z</dct:date>
+        <dct:description>java.lang.AssertionError: tileMatrix definition could not be found expected [true] but found [false]</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest>HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:38 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 2656
+Connection: close
+
+{
+    "links": [
+        {
+            "rel": "about",
+            "type": "text/html",
+            "title": "pygeoapi default instance",
+            "href": "https://example.org"
+        },
+        {
+            "rel": "self",
+            "type": "application/json",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000?f=json"
+        },
+        {
+            "rel": "alternate",
+            "type": "application/ld+json",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000?f=jsonld"
+        },
+        {
+            "rel": "alternate",
+            "type": "text/html",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "service-desc",
+            "type": "application/vnd.oai.openapi+json;version=3.0",
+            "title": "The OpenAPI definition as JSON",
+            "href": "http://localhost:5000/openapi"
+        },
+        {
+            "rel": "service-doc",
+            "type": "text/html",
+            "title": "The OpenAPI definition as HTML",
+            "href": "http://localhost:5000/openapi?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "conformance",
+            "type": "application/json",
+            "title": "Conformance",
+            "href": "http://localhost:5000/conformance"
+        },
+        {
+            "rel": "data",
+            "type": "application/json",
+            "title": "Collections",
+            "href": "http://localhost:5000/collections"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/processes",
+            "type": "application/json",
+            "title": "Processes",
+            "href": "http://localhost:5000/processes"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/job-list",
+            "type": "application/json",
+            "title": "Jobs",
+            "href": "http://localhost:5000/jobs"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "application/json",
+            "title": "The list of supported tiling schemes as JSON",
+            "href": "http://localhost:5000/TileMatrixSets?f=json"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "text/html",
+            "title": "The list of supported tiling schemes as HTML",
+            "href": "http://localhost:5000/TileMatrixSets?f=html"
+        }
+    ],
+    "title": "pygeoapi default instance",
+    "description": "pygeoapi provides an API to geospatial data"
+}
+HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:38 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 20893
+Connection: close
+
+{
+    "collections": [
+        {
+            "id": "obs",
+            "title": "Observations",
+            "description": "My cool observations",
+            "keywords": [
+                "observations",
+                "monitoring"
+            ],
+            "links": [
+                {
+                    "type": "text/csv",
+                    "rel": "canonical",
+                    "title": "data",
+                    "href": "https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "text/csv",
+                    "rel": "alternate",
+                    "title": "data",
+                    "href": "https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/obs?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/obs?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/obs?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/obs/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/obs/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/obs/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/obs/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/obs/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2000-10-30T18:24:39+00:00",
+                            "2007-10-30T08:57:29+00:00"
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "lakes",
+            "title": "Large Lakes",
+            "description": "lakes of the world, public domain",
+            "keywords": [
+                "lakes",
+                "water bodies"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "http://www.naturalearthdata.com/",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/lakes?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/lakes?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/lakes/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/lakes/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2011-11-11T11:11:11+00:00",
+                            null
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "mapserver_world_map",
+            "title": "MapServer demo WMS world map",
+            "description": "MapServer demo WMS world map",
+            "keywords": [
+                "MapServer",
+                "world map"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://demo.mapserver.org",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=html"
+                },
+                {
+                    "type": "image/png",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/map",
+                    "title": "Map as png",
+                    "href": "http://localhost:5000/collections/mapserver_world_map/map?f=png"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "gdps-temperature",
+            "title": "Global Deterministic Prediction System sample",
+            "description": "Global Deterministic Prediction System sample",
+            "keywords": [
+                "gdps",
+                "global"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=html"
+                },
+                {
+                    "type": "application/prs.coverage+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=json"
+                },
+                {
+                    "type": "application/x-grib2",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data as GRIB",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=GRIB"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "canada-metadata",
+            "title": "Open Canada sample data",
+            "description": "Sample metadata records from open.canada.ca",
+            "keywords": [
+                "canada",
+                "open data"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://open.canada.ca/en/open-data",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "informations",
+                    "href": "https://ouvert.canada.ca/fr/donnees-ouvertes",
+                    "hreflang": "fr-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            },
+            "itemType": "record"
+        }
+    ],
+    "links": [
+        {
+            "type": "application/json",
+            "rel": "self",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000/collections?f=json"
+        },
+        {
+            "type": "application/ld+json",
+            "rel": "alternate",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000/collections?f=jsonld"
+        },
+        {
+            "type": "text/html",
+            "rel": "alternate",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000/collections?f=html"
+        }
+    ]
+}
+</cnt:rest>       </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI>Request method:	GET
+Request URI:	http://localhost:5000/
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+Request method:	GET
+Request URI:	http://localhost:5000/collections
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+</http:requestURI>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileMatrixDefinitionIsAvailable">
+        <dct:title>validate Tile Matrix Definition Is Available </dct:title>
+        <dct:description>Implements Abstract test A.3, Requirement 2: /req/core/tc-tilematrix-definition</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-11">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-11">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:41.701Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test>
+      <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/tilesetslist/TilesetLlinks#validateTilesetsListResponse">
+        <dct:title>validate Tilesets List Response </dct:title>
+        <dct:description>Implements Abstract test A.9, addresses Requirement 10 (/req/tilesets-list/tileset-links)</dct:description>
+      </earl:TestCase>
+    </earl:test>
+  </earl:Assertion>
+  <cite:TestRun>
+    <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+    <dct:title>ogcapi-tiles-1.0-1.0</dct:title>
+    <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">9</cite:testsFailed>
+    <dct:created>2025-04-10T14:04:41.756Z</dct:created>
+    <cite:inputs>
+      <rdf:Bag>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>mintilerow</dct:title>
+          <dct:description>0</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>tilematrixsetdefinitionuri</dct:title>
+          <dct:description>http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>iut</dct:title>
+          <dct:description>http://localhost:5000</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>maxtilerow</dct:title>
+          <dct:description>1</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>sessionId</dct:title>
+          <dct:description>s0003</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>maxtilecol</dct:title>
+          <dct:description>1</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>acceptMediaType</dct:title>
+          <dct:description>application/rdf+xml</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>tilematrix</dct:title>
+          <dct:description>0</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>urltemplatefortiles</dct:title>
+          <dct:description>http://localhost:5000/collections/lakes/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>sourcesId</dct:title>
+          <dct:description>OGC_OGC API-tiles 1.0 Conformance Test Suite_1.0</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>mintilecol</dct:title>
+          <dct:description>0</dct:description>
+        </rdf:li>
+        <rdf:li rdf:parseType="Resource">
+          <dct:title>logDir</dct:title>
+          <dct:description>/usr/local/tomcat/te_base/users/ogctest/rest</dct:description>
+        </rdf:li>
+      </rdf:Bag>
+    </cite:inputs>
+    <cite:testSuiteType>testng</cite:testSuiteType>
+    <cite:requirements>
+      <rdf:Seq>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Core">
+            <dct:title>Core</dct:title>
+            <cite:isBasic>true</cite:isBasic>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/core/MandatoryCore#verifyMinimalConformance"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/core/MandatoryCore#verifyErrorResponses"/>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Conditional-Core">
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateSuccessfulTilesExecution"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTilesAreAvailable"/>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTilesErrorConditions">
+                <dct:title>validate Tiles Error Conditions </dct:title>
+                <dct:description>Implements Abstract test A.7: /conf/core/tc-error, Requirement 6: /req/core/tc-error</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileRowDefinitionIsAvailable">
+                <dct:title>validate Tile Row Definition Is Available </dct:title>
+                <dct:description>Implements Abstract test A.4, Requirement 3: /req/core/tc-tilerow-definition</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileMatrixDefinitionIsAvailable"/>
+            <dct:title>Conditional Core</dct:title>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">5</cite:testsFailed>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Conformance#validateConformanceOperationAndResponse"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileColDefinitionIsAvailable"/>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</cite:testsPassed>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="OpenAPI-Specification-3.0">
+            <dct:title>OpenAPI Specification 3.0</dct:title>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/apidefinition/ApiDefinition#apiDefinitionValidation"/>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Tilesets-List">
+            <dct:title>Tilesets List</dct:title>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/tilesetslist/TilesetLlinks#validateTilesetsListResponse"/>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="Dataset-Tilesets">
+            <dct:title>Dataset Tilesets</dct:title>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart>
+              <earl:TestCase rdf:about="org/opengis/cite/ogcapitiles10/datasettilesets/LandingPage#landingPageRetrieval">
+                <dct:title>landing Page Retrieval </dct:title>
+                <dct:description>Implements Abstract test A.10, addresses Requirement 11</dct:description>
+              </earl:TestCase>
+            </dct:hasPart>
+          </earl:TestRequirement>
+        </rdf:li>
+        <rdf:li>
+          <earl:TestRequirement rdf:about="GeoData-Tilesets">
+            <dct:title>GeoData Tilesets</dct:title>
+            <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsPassed>
+            <cite:testsFailed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">2</cite:testsFailed>
+            <cite:testsSkipped rdf:datatype="http://www.w3.org/2001/XMLSchema#int">0</cite:testsSkipped>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/geodatatilesets/GeospatialDataResource#geospatialResourceTilesetsRetrieval"/>
+            <dct:hasPart rdf:resource="org/opengis/cite/ogcapitiles10/geodatatilesets/GeospatialDataResource#geospatialResourceTilesetsLinksCheck"/>
+          </earl:TestRequirement>
+        </rdf:li>
+      </rdf:Seq>
+    </cite:requirements>
+    <dct:identifier>s0003</dct:identifier>
+    <dct:extent rdf:datatype="http://www.w3.org/2001/XMLSchema#duration">PT3.547S</dct:extent>
+    <cite:areCoreConformanceClassesPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</cite:areCoreConformanceClassesPassed>
+    <cite:testsPassed rdf:datatype="http://www.w3.org/2001/XMLSchema#int">5</cite:testsPassed>
+  </cite:TestRun>
+  <earl:Assertion rdf:about="assert-4">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-4">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:38.557Z</dct:date>
+        <dct:description>java.lang.AssertionError: tileRow definition could not be found expected [true] but found [false]</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest>HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:38 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 2656
+Connection: close
+
+{
+    "links": [
+        {
+            "rel": "about",
+            "type": "text/html",
+            "title": "pygeoapi default instance",
+            "href": "https://example.org"
+        },
+        {
+            "rel": "self",
+            "type": "application/json",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000?f=json"
+        },
+        {
+            "rel": "alternate",
+            "type": "application/ld+json",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000?f=jsonld"
+        },
+        {
+            "rel": "alternate",
+            "type": "text/html",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "service-desc",
+            "type": "application/vnd.oai.openapi+json;version=3.0",
+            "title": "The OpenAPI definition as JSON",
+            "href": "http://localhost:5000/openapi"
+        },
+        {
+            "rel": "service-doc",
+            "type": "text/html",
+            "title": "The OpenAPI definition as HTML",
+            "href": "http://localhost:5000/openapi?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "conformance",
+            "type": "application/json",
+            "title": "Conformance",
+            "href": "http://localhost:5000/conformance"
+        },
+        {
+            "rel": "data",
+            "type": "application/json",
+            "title": "Collections",
+            "href": "http://localhost:5000/collections"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/processes",
+            "type": "application/json",
+            "title": "Processes",
+            "href": "http://localhost:5000/processes"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/job-list",
+            "type": "application/json",
+            "title": "Jobs",
+            "href": "http://localhost:5000/jobs"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "application/json",
+            "title": "The list of supported tiling schemes as JSON",
+            "href": "http://localhost:5000/TileMatrixSets?f=json"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "text/html",
+            "title": "The list of supported tiling schemes as HTML",
+            "href": "http://localhost:5000/TileMatrixSets?f=html"
+        }
+    ],
+    "title": "pygeoapi default instance",
+    "description": "pygeoapi provides an API to geospatial data"
+}
+HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:38 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 20893
+Connection: close
+
+{
+    "collections": [
+        {
+            "id": "obs",
+            "title": "Observations",
+            "description": "My cool observations",
+            "keywords": [
+                "observations",
+                "monitoring"
+            ],
+            "links": [
+                {
+                    "type": "text/csv",
+                    "rel": "canonical",
+                    "title": "data",
+                    "href": "https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "text/csv",
+                    "rel": "alternate",
+                    "title": "data",
+                    "href": "https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/obs?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/obs?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/obs?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/obs/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/obs/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/obs/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/obs/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/obs/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/obs/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2000-10-30T18:24:39+00:00",
+                            "2007-10-30T08:57:29+00:00"
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "lakes",
+            "title": "Large Lakes",
+            "description": "lakes of the world, public domain",
+            "keywords": [
+                "lakes",
+                "water bodies"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "http://www.naturalearthdata.com/",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/lakes?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/lakes?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/lakes/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/lakes/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/lakes/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/lakes/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/lakes/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                },
+                "temporal": {
+                    "interval": [
+                        [
+                            "2011-11-11T11:11:11+00:00",
+                            null
+                        ]
+                    ]
+                }
+            },
+            "itemType": "feature",
+            "crs": [
+                "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            ],
+            "storageCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        },
+        {
+            "id": "mapserver_world_map",
+            "title": "MapServer demo WMS world map",
+            "description": "MapServer demo WMS world map",
+            "keywords": [
+                "MapServer",
+                "world map"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://demo.mapserver.org",
+                    "hreflang": "en-US"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/mapserver_world_map?f=html"
+                },
+                {
+                    "type": "image/png",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/map",
+                    "title": "Map as png",
+                    "href": "http://localhost:5000/collections/mapserver_world_map/map?f=png"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "gdps-temperature",
+            "title": "Global Deterministic Prediction System sample",
+            "description": "Global Deterministic Prediction System sample",
+            "keywords": [
+                "gdps",
+                "global"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/gdps-temperature/schema?f=html"
+                },
+                {
+                    "type": "application/prs.coverage+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=json"
+                },
+                {
+                    "type": "application/x-grib2",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                    "title": "Coverage data as GRIB",
+                    "href": "http://localhost:5000/collections/gdps-temperature/coverage?f=GRIB"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        },
+        {
+            "id": "canada-metadata",
+            "title": "Open Canada sample data",
+            "description": "Sample metadata records from open.canada.ca",
+            "keywords": [
+                "canada",
+                "open data"
+            ],
+            "links": [
+                {
+                    "type": "text/html",
+                    "rel": "canonical",
+                    "title": "information",
+                    "href": "https://open.canada.ca/en/open-data",
+                    "hreflang": "en-CA"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "informations",
+                    "href": "https://ouvert.canada.ca/fr/donnees-ouvertes",
+                    "hreflang": "fr-CA"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "root",
+                    "title": "The landing page of this server as JSON",
+                    "href": "http://localhost:5000?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "root",
+                    "title": "The landing page of this server as HTML",
+                    "href": "http://localhost:5000?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "self",
+                    "title": "This document as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "alternate",
+                    "title": "This document as RDF (JSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "alternate",
+                    "title": "This document as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata?f=html"
+                },
+                {
+                    "type": "application/json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/schema",
+                    "title": "Schema of collection in HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/schema?f=html"
+                },
+                {
+                    "type": "application/schema+json",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as JSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=json"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/queryables",
+                    "title": "Queryables for this collection as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/queryables?f=html"
+                },
+                {
+                    "type": "application/geo+json",
+                    "rel": "items",
+                    "title": "Items as GeoJSON",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=json"
+                },
+                {
+                    "type": "application/ld+json",
+                    "rel": "items",
+                    "title": "Items as RDF (GeoJSON-LD)",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=jsonld"
+                },
+                {
+                    "type": "text/html",
+                    "rel": "items",
+                    "title": "Items as HTML",
+                    "href": "http://localhost:5000/collections/canada-metadata/items?f=html"
+                }
+            ],
+            "extent": {
+                "spatial": {
+                    "bbox": [
+                        [
+                            -180,
+                            -90,
+                            180,
+                            90
+                        ]
+                    ],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            },
+            "itemType": "record"
+        }
+    ],
+    "links": [
+        {
+            "type": "application/json",
+            "rel": "self",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000/collections?f=json"
+        },
+        {
+            "type": "application/ld+json",
+            "rel": "alternate",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000/collections?f=jsonld"
+        },
+        {
+            "type": "text/html",
+            "rel": "alternate",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000/collections?f=html"
+        }
+    ]
+}
+</cnt:rest>       </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI>Request method:	GET
+Request URI:	http://localhost:5000/
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+Request method:	GET
+Request URI:	http://localhost:5000/collections
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+</http:requestURI>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTileRowDefinitionIsAvailable"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-12">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-12">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:41.712Z</dct:date>
+        <dct:description>java.lang.AssertionError: Requirement 11 states that if the API has a mechanism for exposing root resources (e.g., a landing page), the API SHALL advertise at least one URI to retrieve a tilesets list provided by this service with a link having a rel value: http://www.opengis.net/def/rel/ogc/1.0/tilesets-vector, http://www.opengis.net/def/rel/ogc/1.0/tilesets-map or http://www.opengis.net/def/rel/ogc/1.0/tilesets-coverage. However, the landing page did not have any such links.</dct:description>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#failed"/>
+        <cite:message>
+          <http:Request>
+            <http:resp>
+              <http:Response>
+                <http:body>
+                  <cnt:ContentAsXML>
+                    <cnt:rest>HTTP/1.1 200 OK
+Server: Werkzeug/3.1.3 Python/3.10.12
+Date: Thu, 10 Apr 2025 14:04:41 GMT
+Content-Type: application/json
+X-Powered-By: pygeoapi 0.18.dev0
+Content-Language: en-US
+Content-Length: 2656
+Connection: close
+
+{
+    "links": [
+        {
+            "rel": "about",
+            "type": "text/html",
+            "title": "pygeoapi default instance",
+            "href": "https://example.org"
+        },
+        {
+            "rel": "self",
+            "type": "application/json",
+            "title": "This document as JSON",
+            "href": "http://localhost:5000?f=json"
+        },
+        {
+            "rel": "alternate",
+            "type": "application/ld+json",
+            "title": "This document as RDF (JSON-LD)",
+            "href": "http://localhost:5000?f=jsonld"
+        },
+        {
+            "rel": "alternate",
+            "type": "text/html",
+            "title": "This document as HTML",
+            "href": "http://localhost:5000?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "service-desc",
+            "type": "application/vnd.oai.openapi+json;version=3.0",
+            "title": "The OpenAPI definition as JSON",
+            "href": "http://localhost:5000/openapi"
+        },
+        {
+            "rel": "service-doc",
+            "type": "text/html",
+            "title": "The OpenAPI definition as HTML",
+            "href": "http://localhost:5000/openapi?f=html",
+            "hreflang": "en-US"
+        },
+        {
+            "rel": "conformance",
+            "type": "application/json",
+            "title": "Conformance",
+            "href": "http://localhost:5000/conformance"
+        },
+        {
+            "rel": "data",
+            "type": "application/json",
+            "title": "Collections",
+            "href": "http://localhost:5000/collections"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/processes",
+            "type": "application/json",
+            "title": "Processes",
+            "href": "http://localhost:5000/processes"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/job-list",
+            "type": "application/json",
+            "title": "Jobs",
+            "href": "http://localhost:5000/jobs"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "application/json",
+            "title": "The list of supported tiling schemes as JSON",
+            "href": "http://localhost:5000/TileMatrixSets?f=json"
+        },
+        {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/tiling-schemes",
+            "type": "text/html",
+            "title": "The list of supported tiling schemes as HTML",
+            "href": "http://localhost:5000/TileMatrixSets?f=html"
+        }
+    ],
+    "title": "pygeoapi default instance",
+    "description": "pygeoapi provides an API to geospatial data"
+}
+</cnt:rest>       </cnt:ContentAsXML>
+                </http:body>
+              </http:Response>
+            </http:resp>
+            <http:requestURI>Request method:	GET
+Request URI:	http://localhost:5000/
+Proxy:			&lt;none&gt;
+Request params:	&lt;none&gt;
+Query params:	&lt;none&gt;
+Form params:	&lt;none&gt;
+Path params:	&lt;none&gt;
+Headers:		Accept=application/json, application/javascript, text/javascript, text/json
+Cookies:		&lt;none&gt;
+Multiparts:		&lt;none&gt;
+Body:			&lt;none&gt;
+</http:requestURI>
+            <http:methodName>GET</http:methodName>
+          </http:Request>
+        </cite:message>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapitiles10/datasettilesets/LandingPage#landingPageRetrieval"/>
+  </earl:Assertion>
+  <earl:Assertion rdf:about="assert-8">
+    <earl:mode rdf:resource="http://www.w3.org/ns/earl#automatic"/>
+    <earl:assertedBy rdf:resource="https://github.com/opengeospatial/teamengine"/>
+    <earl:subject rdf:resource="http://localhost:5000"/>
+    <earl:result>
+      <earl:TestResult rdf:about="result-8">
+        <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-10T14:04:38.579Z</dct:date>
+        <earl:outcome rdf:resource="http://www.w3.org/ns/earl#passed"/>
+      </earl:TestResult>
+    </earl:result>
+    <earl:test rdf:resource="org/opengis/cite/ogcapitiles10/conformance/Tile#validateTilesErrorConditions"/>
+  </earl:Assertion>
+</rdf:RDF>


### PR DESCRIPTION
This PR surfaces the `TestStatus.CANT_TELL` test status in the output reports for markdown and console. It also cleans up the default Markdown template.

---

- fixes #30 
- fixes #57 