### PR TITLE
Made CI workflow reusable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
       - name: "Upload built package as artifact"
         id: upload_package_artifact
         uses: actions/upload-artifact@v4
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           name: "${{ env.ARTIFACT_NAME }}"
           path: dist/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: "Grab code"
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: "0"
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,16 +1,29 @@
 name: Continuous Integration
 
 on:
-  push:  # will run both when pushing a branch and when pushing a tag
+  # will run both when pushing a branch and when pushing a tag
+  push:
 
   pull_request:
+
+  # will run when called from another workflow
+  workflow_call:
+    outputs:
+      artifact_name:
+        description: "Name of the artifact containing the build package"
+        value: ${{ jobs.run_ci.outputs.artifact_name }}
+
 
 env:
   COLUMNS: 120
 
 jobs:
-  run-ci:
+  run_ci:
     runs-on: ubuntu-24.04
+    env:
+      ARTIFACT_NAME: "python-package"
+    outputs:
+      artifact_name: ${{ env.ARTIFACT_NAME }}
     steps:
       - name: "Grab code"
         uses: actions/checkout@v4.2.2
@@ -38,3 +51,14 @@ jobs:
 
       - name: "Run tests"
         run: uv run pytest
+
+      - name: "Build Python package"
+        run: uv build
+
+      - name: "Upload built package as artifact"
+        id: upload_package_artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ env.ARTIFACT_NAME }}"
+          path: dist/
+          retention-days: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
+_version.py
 
 .idea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
+dynamic = [
+    "version"
+]
 name = "cite-runner"
-version = "0.1.0"
 description = "A runner for OGC CITE test suites"
 license = "MIT"
 license-files = [
@@ -75,3 +77,9 @@ name = "testpypi"
 url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
 explicit = true
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,5 +81,8 @@ explicit = true
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+version_scheme = "python-simplified-semver"
+
 [tool.hatch.build.hooks.vcs]
 version-file = "_version.py"

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,6 @@ wheels = [
 
 [[package]]
 name = "cite-runner"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This PR make the CI workflow reusable.

Also added additional steps to build the Python package and upload it as an artifact. The artifact name has also been added as a job output. This will allow reusing this workflow for publishing the built package

The built python package gets its version from git

---

- fixes #75