### PR TITLE
Adding a workflow for managing releases

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,13 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: New features
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,23 +15,27 @@ jobs:
   release:
     needs: call_run_ci
     runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/cite-runner
+#    permissions:
+#      id-token: write
+#    environment:
+#      name: testpypi
+#      url: https://test.pypi.org/p/cite-runner
     steps:
       - name: "Download artifact"
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.call_run_ci.outputs.artifact_name }}
           path: dist
-      - name: "Publish to testpypi"
-        uses: pypa/gh-action-pypi-publish@v1.12.4
-        with:
-          attestations: "true"
-          repository-url: "https://test.pypi.org/legacy/"
       - name: "Create GitHub release"
         uses: softprops/action-gh-release@v2.2.1
         with:
           files: dist/*
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          body_path: CHANGELOG.md
+          append_body: true
+#      - name: "Publish to testpypi"
+#        uses: pypa/gh-action-pypi-publish@v1.12.4
+#        with:
+#          attestations: "true"
+#          repository-url: "https://test.pypi.org/legacy/"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  COLUMNS: 120
+
+jobs:
+  call_run_ci:
+    uses: ./.github/workflows/ci.yaml
+
+  release:
+    needs: call_run_ci
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/cite-runner
+    steps:
+      - name: "Download artifact"
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.call_run_ci.outputs.artifact_name }}
+          path: dist
+      - name: "Publish to testpypi"
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          attestations: "true"
+          repository-url: "https://test.pypi.org/legacy/"
+      - name: "Create GitHub release"
+        uses: softprops/action-gh-release@v2.2.1
+        with:
+          files: dist/*


### PR DESCRIPTION
This PR adds a workflow for managing GitHub releases. 

The added workflow is called whenever a new tag with pattern `v*` is pushed. It reuses the existing `ci.yaml` workflow for building a Python package and then creates a release with it.

---

- fixes #70 