### PR TITLE
Added note about running team engine on the documentation

### DIFF
--- a/docs/running-as-standalone-cli.md
+++ b/docs/running-as-standalone-cli.md
@@ -55,6 +55,10 @@ docker run \
     ogccite/teamengine-production:1.0-SNAPSHOT
 ```
 
+!!! warning
+
+    You can only run the `host` networking driver on Linux machines. For more details, please refer to the [official docker documentation]: https://docs.docker.com/engine/network/tutorials/host/#prerequisites
+
 This will spawn a teamengine instance, which will be running locally on port `8080` - it will thus be accessible
 at:
 


### PR DESCRIPTION
```
docker run \
    --rm \
    --name=teamengine \
    --network=host \
    ogccite/teamengine-production:1.0-SNAPSHOT
```

The `network=host`  option when running team engine, required to run the tests, does not work on mac.

https://docs.docker.com/engine/network/tutorials/host/#prerequisites