### PR TITLE
Ensure a full git clone is used when running in GitHub actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,11 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version-file: "${{ github.action_path }}/pyproject.toml"
+    - name: "ensure full git repo is present"
+      shell: "bash"
+      run: |
+        cd ${{ github.action_path }}
+        git fetch --unshallow
     - name: "Install cite-runner"
       shell: "bash"
       run: |


### PR DESCRIPTION
This PR modifies the GitHub action file in order to ensure that the local clone is not shallow and has full history.

This is needed for the installation of cite-runner via `uv` because it is using dynamic versioning.

---

- fixes #86