### PR TITLE
Add a workflow for testing github action

### DIFF
--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -1,0 +1,10 @@
+name: Continuous Integration
+
+env:
+  COLUMNS: 120
+
+jobs:
+  run_ci:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "launch test server"

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -16,7 +16,7 @@ jobs:
   test_cite_runner_github_action:
     runs-on: ubuntu-24.04
     env:
-      SIMPLESERVER_PORT: 9082
+      SIMPLESERVER_PORT: 9092
     steps:
       - name: "Grab code"
         uses: actions/checkout@v4.2.2
@@ -26,9 +26,9 @@ jobs:
           python-version-file: "pyproject.toml"
       - name: "Launch simple test server"
         run: |
-          python tests/simpleserver.py --bind-address 0.0.0.0 --bind-port ${{ env.SIMPLESERVER_PORT }} > /dev/null &
+          nohup python tests/simpleserver.py --bind-address 0.0.0.0 --bind-port ${{ env.SIMPLESERVER_PORT }} > /dev/null 2>&1 &
           echo $! > simpleserver.pid
-          sleep 3
+          sleep 1
           if ps --pid $(cat simpleserver.pid) > /dev/null; then
               echo "simpleserver is up and running with PID $(cat simpleserver.pid)"
           else
@@ -36,10 +36,17 @@ jobs:
               exit 1
           fi
       - name: "Test cite-runner GitHub action"
+        id: test_cite_runner_github_action
         uses: ./
         with:
           test_suite_identifier: ogcapi-features-1.0
           test_session_arguments: iut=http://host.docker.internal:${{ env.SIMPLESERVER_PORT }}
+          exit_with_error: "false"
+      - name: "Verify cite-runner results"
+        run: |
+          jq '.' <<EOF | python tests/github_action_tests.py -
+          ${{ steps.test_cite_runner_github_action.outputs.json_report }}
+          EOF
       - name: "Shut down simple test server"
         if: always()
         run: |

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -16,7 +16,7 @@ jobs:
   test_cite_runner_github_action:
     runs-on: ubuntu-24.04
     env:
-      SIMPLESERVER_PORT: 8000
+      SIMPLESERVER_PORT: 9082
     steps:
       - name: "Grab code"
         uses: actions/checkout@v4.2.2
@@ -26,7 +26,7 @@ jobs:
           python-version-file: "pyproject.toml"
       - name: "Launch simple test server"
         run: |
-          python tests/simpleserver.py --bind-port ${{ env.SIMPLESERVER_PORT }} > /dev/null &
+          python tests/simpleserver.py --bind-address 0.0.0.0 --bind-port ${{ env.SIMPLESERVER_PORT }} > /dev/null &
           echo $! > simpleserver.pid
           sleep 3
           if ps --pid $(cat simpleserver.pid) > /dev/null; then
@@ -39,7 +39,7 @@ jobs:
         uses: ./
         with:
           test_suite_identifier: ogcapi-features-1.0
-          test_session_arguments: iut=http://localhost:${{ env.SIMPLESERVER_PORT }}
+          test_session_arguments: iut=http://host.docker.internal:${{ env.SIMPLESERVER_PORT }}
       - name: "Shut down simple test server"
         if: always()
         run: |

--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -1,10 +1,50 @@
-name: Continuous Integration
+name: Test cite-runner as a GitHub action
+
+on:
+  # will run both when pushing a branch and when pushing a tag
+  push:
+
+  pull_request:
+
+  # will run when called from another workflow
+  workflow_call:
 
 env:
   COLUMNS: 120
 
 jobs:
-  run_ci:
+  test_cite_runner_github_action:
     runs-on: ubuntu-24.04
+    env:
+      SIMPLESERVER_PORT: 8000
     steps:
-      - name: "launch test server"
+      - name: "Grab code"
+        uses: actions/checkout@v4.2.2
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+      - name: "Launch simple test server"
+        run: |
+          python tests/simpleserver.py --bind-port ${{ env.SIMPLESERVER_PORT }} > /dev/null &
+          echo $! > simpleserver.pid
+          sleep 3
+          if ps --pid $(cat simpleserver.pid) > /dev/null; then
+              echo "simpleserver is up and running with PID $(cat simpleserver.pid)"
+          else
+              echo "simpleserver failed to start"
+              exit 1
+          fi
+      - name: "Test cite-runner GitHub action"
+        uses: ./
+        with:
+          test_suite_identifier: ogcapi-features-1.0
+          test_session_arguments: iut=http://localhost:${{ env.SIMPLESERVER_PORT }}
+      - name: "Shut down simple test server"
+        if: always()
+        run: |
+          if [ -f server.pid ]; then
+              echo "Shutting down simpleserver with PID $(cat simpleserver.pid)..."
+              kill $(cat simpleserver.pid) || true
+              rm simpleserver.pid
+          fi

--- a/action.yml
+++ b/action.yml
@@ -50,9 +50,9 @@ inputs:
     description: Whether the action exits with an error if the test suite execution shows a result of failed.
 
 outputs:
-  results:
-    description: "Test results"
-    value: '${{ steps.run_cite_runner.outputs.MARKDOWN_RESULT_OUTPUT_PATH }}'
+  json_report:
+    description: "Full test suite execution result as JSON"
+    value: '${{ steps.run_cite_runner.outputs.JSON_REPORT }}'
 
 runs:
   using: 'composite'
@@ -60,12 +60,17 @@ runs:
     - name: "Add action path to the global path"
       shell: bash
       run: echo "${{ github.action_path }}" >> ${GITHUB_PATH}
+    - name: "normalize action path"
+      id: normalize_action_path
+      shell: "bash"
+      run: |
+        echo "ACTION_NORMALIZED_PATH=$(realpath -m ${{ github.action_path }})" >> "${GITHUB_OUTPUT}"
     - name: "Install uv"
       uses: astral-sh/setup-uv@v5
       with:
         version: "0.6.13"
         enable-cache: true
-        cache-dependency-glob: "${{ github.action_path }}/uv.lock"
+        cache-dependency-glob: "${{ steps.normalize_action_path.outputs.ACTION_NORMALIZED_PATH }}/uv.lock"
     - name: "Set up Python"
       uses: actions/setup-python@v5
       with:
@@ -131,6 +136,10 @@ runs:
             ${RAW_PATH} 1> ${MARKDOWN_PATH}
         cat ${MARKDOWN_PATH} >> ${GITHUB_STEP_SUMMARY}
         echo "MARKDOWN_RESULT_OUTPUT_PATH=${{ github.action_path }}/${MARKDOWN_PATH}" >> "${GITHUB_OUTPUT}"
+        echo "JSON_REPORT=$(uv run cite-runner parse-result \
+            --output-format json \
+            ${RAW_PATH}
+        )" >> "${GITHUB_OUTPUT}"
     - name: "Store execution results as artifacts"
       uses: actions/upload-artifact@v4
       with:

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,9 @@ runs:
         python-version-file: "${{ github.action_path }}/pyproject.toml"
     - name: "Install cite-runner"
       env:
-        SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CITE_RUNNER: ${{ github.action_ref }}
+#        GITHUB_CONTEXT: ${{ toJSON(github) }}
+#        ENV_CONTEXT: ${{ toJSON(env) }}
+        SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CITE_RUNNER: ${{ env.GITHUB_ACTION_REF }}
       shell: "bash"
       run: |
         cd ${{ github.action_path }}

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ runs:
             echo "Unable to use TeamEngine to execute test suite ${{ inputs.test_suite_identifier }} with arguments ${{ inputs.test_session_arguments }}"
             exit 1
         fi
-        echo "RAW_RESULT_OUTPUT_PATH=${{ github.action_path }}/${RAW_PATH}" >> "${GITHUB_OUTPUT}"
+        echo "RAW_RESULT_OUTPUT_PATH=${{ steps.normalize_action_path.outputs.ACTION_NORMALIZED_PATH }}/${RAW_PATH}" >> "${GITHUB_OUTPUT}"
         echo "::group::cite-runner suite execution results"
         uv run cite-runner parse-result \
             --output-format console \
@@ -135,7 +135,7 @@ runs:
             ${{ fromJSON(inputs.with_passed) && '--with-passed \' || '--without-passed \'}}
             ${RAW_PATH} 1> ${MARKDOWN_PATH}
         cat ${MARKDOWN_PATH} >> ${GITHUB_STEP_SUMMARY}
-        echo "MARKDOWN_RESULT_OUTPUT_PATH=${{ github.action_path }}/${MARKDOWN_PATH}" >> "${GITHUB_OUTPUT}"
+        echo "MARKDOWN_RESULT_OUTPUT_PATH=${{ steps.normalize_action_path.outputs.ACTION_NORMALIZED_PATH }}/${MARKDOWN_PATH}" >> "${GITHUB_OUTPUT}"
         echo "JSON_REPORT=$(uv run cite-runner parse-result \
             --output-format json \
             ${RAW_PATH}

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,8 @@ runs:
         --detach
         --rm
         --name teamengine
-        --network host
+        --add-host=host.docker.internal:host-gateway
+        --publish 9080:8080
         ogccite/teamengine-production:1.0-SNAPSHOT
     - name: "Run cite-runner"
       id: "run_cite_runner"
@@ -98,12 +99,16 @@ runs:
         uv run cite-runner \
             --network-timeout=${{ inputs.network_timeout_seconds }} \
             execute-test-suite-from-github-actions \
-            ${{ inputs.teamengine_url || 'http://localhost:8080/teamengine' }} \
+            ${{ inputs.teamengine_url || 'http://localhost:9080/teamengine' }} \
             ${{ inputs.test_suite_identifier }} \
             --output-format=raw \
             --teamengine-username=${{ inputs.teamengine_username }} \
             --teamengine-password=${{ inputs.teamengine_password }} \
             $(echo -e ${{ inputs.test_session_arguments }}) 1> ${RAW_PATH}
+        if [ $? -ne 0 ]; then
+            echo "Unable to use TeamEngine to execute test suite ${{ inputs.test_suite_identifier }} with arguments ${{ inputs.test_session_arguments }}"
+            exit 1
+        fi
         echo "RAW_RESULT_OUTPUT_PATH=${{ github.action_path }}/${RAW_PATH}" >> "${GITHUB_OUTPUT}"
         echo "::group::cite-runner suite execution results"
         uv run cite-runner parse-result \
@@ -127,15 +132,14 @@ runs:
         cat ${MARKDOWN_PATH} >> ${GITHUB_STEP_SUMMARY}
         echo "MARKDOWN_RESULT_OUTPUT_PATH=${{ github.action_path }}/${MARKDOWN_PATH}" >> "${GITHUB_OUTPUT}"
     - name: "Store execution results as artifacts"
-      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
         name: 'execution-results-${{ inputs.test_suite_identifier }}'
         path: |
           ${{ steps.run_cite_runner.outputs.RAW_RESULT_OUTPUT_PATH }}
           ${{ steps.run_cite_runner.outputs.MARKDOWN_RESULT_OUTPUT_PATH }}
-    - name: "Stop TEAM engine container"
-      if: ${{ !cancelled() && !inputs.teamengine_url }}
+    - name: "Stop teamengine container"
+      if: ${{ always() && !inputs.teamengine_url }}
       shell: "bash"
       run: docker stop teamengine
     - name: "Set action exit code"

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,7 +77,23 @@ In a brief nutshell:
     uv run cite-runner
     ```
 
-8. If you want to work on documentation, you can start the mkdocs server with:
+9. Run tests with:
+
+    ```shell
+    uv run pytest
+    ```
+
+9. If you want to test running cite-runner as a GitHub action, install [act:material-open-in-new:]{: target="blank_" }
+   and run:
+
+    ```shell
+    act \
+        --rm \
+        --workflows .github/workflows/test-action.yaml \
+        -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04
+    ```
+
+10. If you want to work on documentation, you can start the mkdocs server with:
 
     ```shell
     uv run mkdocs serve
@@ -100,6 +116,7 @@ set up to run whenever a new tag named `v*` is pushed to the repository. This wo
 
 
 
+[act:material-open-in-new:]: https://nektosact.com/introduction.html
 [GitHub actions workflow:material-open-in-new:]: https://github.com/OSGeo/cite-runner/blob/main/.github/workflows/release.yaml
 [httpx:material-open-in-new:]: https://www.python-httpx.org/
 [jinja:material-open-in-new:]: https://jinja.palletsprojects.com/en/stable/

--- a/docs/development.md
+++ b/docs/development.md
@@ -57,17 +57,20 @@ In a brief nutshell:
     docker run \
         --rm \
         --name=teamengine \
-        --network=host \
+        --add-host=host.docker.internal:host-gateway \
+        --publish=9080:8080 \
         ogccite/teamengine-production:1.0-SNAPSHOT
     ```
 
-    You should now be able to use `http:localhost:8080/teamengine` in
-    cite-runner
+    You should now be able to use `http:localhost:9080/teamengine` in
+    cite-runner.
 
-    !!! warning
+    !!! note
 
-        teamengine will try to run on your local port `8080`, which could
-        potentially already be occupied by another application.
+        Using docker's `--add-host=host.docker.internal:host-gateway` is necessary when running
+        docker engine, as discussed in the [docker engine docs:material-open-in-new:]{: target="blank_" }. If
+        you are using docker desktop you can omit this flag.
+
 
 7. Work on the cite-runner code
 
@@ -76,6 +79,19 @@ In a brief nutshell:
     ```shell
     uv run cite-runner
     ```
+
+    !!! warning
+
+         When using cite-runner with a local teamengine instance that is running via docker and also testing an
+         OGC service that is running locally on the same machine, you must not use `localhost` when providing the
+         service's URL to teamengine, but rather use `host.docker.internal`. As an example:
+
+         ```shell
+         uv run cite-runner execute-test-suite \
+             http://localhost:9081/teamengine \
+             ogcapi-features-1.0 \
+             --suite-input iut http://host.docker.internal:9082
+         ```
 
 9. Run tests with:
 
@@ -90,7 +106,7 @@ In a brief nutshell:
     act \
         --rm \
         --workflows .github/workflows/test-action.yaml \
-        -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04
+        --platform ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04
     ```
 
 10. If you want to work on documentation, you can start the mkdocs server with:
@@ -117,6 +133,7 @@ set up to run whenever a new tag named `v*` is pushed to the repository. This wo
 
 
 [act:material-open-in-new:]: https://nektosact.com/introduction.html
+[docker engine docs:material-open-in-new:]: https://docs.docker.com/reference/cli/docker/container/run/#add-host
 [GitHub actions workflow:material-open-in-new:]: https://github.com/OSGeo/cite-runner/blob/main/.github/workflows/release.yaml
 [httpx:material-open-in-new:]: https://www.python-httpx.org/
 [jinja:material-open-in-new:]: https://jinja.palletsprojects.com/en/stable/

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,7 +62,7 @@ In a brief nutshell:
         ogccite/teamengine-production:1.0-SNAPSHOT
     ```
 
-    You should now be able to use `http:localhost:9080/teamengine` in
+    You should now be able to use `http:localhost:9080/teamengine` as the teamengine URL in
     cite-runner.
 
     !!! note
@@ -71,10 +71,7 @@ In a brief nutshell:
         docker engine, as discussed in the [docker engine docs:material-open-in-new:]{: target="blank_" }. If
         you are using docker desktop you can omit this flag.
 
-
-7. Work on the cite-runner code
-
-8. You can run cite-runner via uv with:
+7.  You can run cite-runner via uv with:
 
     ```shell
     uv run cite-runner
@@ -84,7 +81,9 @@ In a brief nutshell:
 
          When using cite-runner with a local teamengine instance that is running via docker and also testing an
          OGC service that is running locally on the same machine, you must not use `localhost` when providing the
-         service's URL to teamengine, but rather use `host.docker.internal`. As an example:
+         service's URL to teamengine, but rather use `host.docker.internal`.
+
+         As an example:
 
          ```shell
          uv run cite-runner execute-test-suite \
@@ -93,27 +92,43 @@ In a brief nutshell:
              --suite-input iut http://host.docker.internal:9082
          ```
 
-9. Run tests with:
 
-    ```shell
-    uv run pytest
-    ```
+### Running tests
 
-9. If you want to test running cite-runner as a GitHub action, install [act:material-open-in-new:]{: target="blank_" }
-   and run:
+Most tests can be run with:
 
-    ```shell
-    act \
-        --rm \
-        --workflows .github/workflows/test-action.yaml \
-        --platform ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04
-    ```
+ ```shell
+ uv run pytest
+ ```
 
-10. If you want to work on documentation, you can start the mkdocs server with:
+cite-runner also includes a workflow for testing itself when running as a GitHub action. This can be run locally
+with a tool like [act:material-open-in-new:]{: target="blank_" }.
 
-    ```shell
-    uv run mkdocs serve
-    ```
+ ```shell
+ act \
+     --workflows .github/workflows/test-action.yaml \
+     --rm \
+     --platform ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04 \
+     --container-options="-p 9092:9092" \
+     --artifact-server-path $PWD/.artifacts
+ ```
+
+The `.github/workflows/test-action.yaml` workflow launches a simple HTTP server which contains a very incomplete
+implementation of OGC API - Features and then uses the cite-runner GitHub action to run the `ogcapi-features-1.0`
+test suite on it. It then captures the cite-runner output, and runs it through some Python tests to verify the
+result matches what is expected.
+
+
+### Documentation
+
+If you want to work on documentation, you can start the mkdocs server with:
+
+ ```shell
+ uv run mkdocs serve
+ ```
+
+Now edit files under the `/docs` directory and check whether they match your expected result in the mkdocs dev server,
+which would be running at `http://localhost:8000/cite-runner/
 
 
 ## Release management

--- a/docs/running-as-github-action.md
+++ b/docs/running-as-github-action.md
@@ -18,9 +18,6 @@ and specify which test suite to run, alongside any relevant parameters.
     Although cite-runner is not yet published in the [GitHub marketplace:material-open-in-new:]{: target="blank_" } it
     can still be used in GitHub CI workflows.
 
-[GitHub action:material-open-in-new:]: https://docs.github.com/en/actions/sharing-automations/creating-actions/about-custom-actions
-[GitHub marketplace:material-open-in-new:]: https://github.com/marketplace
-
 Include it as any other GitHub action, by creating a workflow step that
 specifies `uses: OSGEO/cite-runner` and provide execution parameters in the
 `with` parameter.
@@ -202,10 +199,35 @@ When run as a GitHub action, cite-runner expects the following inputs to be prov
 
 
 
-[GitHub actions inputs:material-open-in-new:]: https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#inputs
-[fromJSON() function:material-open-in-new:]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#fromjson
-[ternary operator:material-open-in-new:]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators
+## Outputs
 
+The cite-runner GitHub Action will provide a single output, which is a full report of the test suite results:
+
+
+### json_report
+
+This is a JSON document containing the full parsed test suite execution results. You can use it in further GitHub
+workflow steps to verify suite execution. As an example of further processing, you can pipe the result to
+[jq:material-open-in-new:]{: target="blank_" }, as seen below:
+
+```yaml
+- name: "Verify cite-runner results"
+  run: |
+  jq '.passed' <<EOF
+  ${{ steps.test_cite_runner_github_action.outputs.json_report }}
+  EOF
+```
+
+!!! tip
+
+    Handling outputs of a GitHub Action that represent JSON data can be a bit tricky. The previous example showcases
+    using a [HERE doc:material-open-in-new:]{: target="blank_" }, which has the benefit of preserving whatever
+    double/single quotes may be present in the underlying JSON data. We recommend always using this technique to
+    process cite-runner GitHub Action's output
+
+
+[cite-runner's own testing workflow:material-open-in-new:]{: target="blank_" } has an additional example of using
+the action's output and passing it to another command for further processing.
 
 ## Usage examples
 
@@ -422,6 +444,15 @@ relevant steps consist of calling cite-runner as a standalone CLI application. B
 7. Finally, set the action exit code. This is done by retrieving the exit code that had been stored in 4.2 and using it
    to set the overall action exit code.
 
+
+[cite-runner's own testing workflow:material-open-in-new:]: https://github.com/OSGeo/cite-runner/tree/main/.github/workflows/test-action.yaml
 [composite action:material-open-in-new:]: https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action
 [custom shell:material-open-in-new:]: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+[jq:material-open-in-new:]: https://jqlang.org/
+[fromJSON() function:material-open-in-new:]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#fromjson
+[GitHub action:material-open-in-new:]: https://docs.github.com/en/actions/sharing-automations/creating-actions/about-custom-actions
+[GitHub actions inputs:material-open-in-new:]: https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#inputs
+[GitHub marketplace:material-open-in-new:]: https://github.com/marketplace
+[HERE doc:material-open-in-new:]: https://linuxize.com/post/bash-heredoc/
 [set -e:material-open-in-new:]: https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#The-Set-Builtin
+[ternary operator:material-open-in-new:]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators

--- a/docs/running-as-standalone-cli.md
+++ b/docs/running-as-standalone-cli.md
@@ -47,19 +47,22 @@ docker pull ogccite/teamengine-production:1.0-SNAPSHOT
 docker run \
     --rm \
     --name=teamengine \
-    --network=host \
+    --add-host=host.docker.internal:host-gateway \
+    --publish=9080:8080 \
     ogccite/teamengine-production:1.0-SNAPSHOT
 ```
 
-!!! warning
+!!! note
 
-    You can only run the `host` networking driver on Linux machines. For more details, please refer to the
-    [official docker documentation:material-open-in-new:]{: target="blank_" }.
+    Using docker's `--add-host=host.docker.internal:host-gateway` is only necessary when running bare docker engine,
+    as discussed in the [docker engine docs:material-open-in-new:]{: target="blank_" }. If you are using docker
+    desktop you can omit this flag.
 
-This will spawn a teamengine instance, which will be running locally on port `8080` - it will thus be accessible
+
+This will spawn a teamengine instance, which will be running locally on port `9080` - it will thus be accessible
 at:
 
-<http://localhost:8080/teamengine>
+<http://localhost:9080/teamengine>
 
 !!! warning
 
@@ -106,7 +109,7 @@ cite runner execute-test-suite [OPTIONS] TEAMENGINE_BASE_URL TEST_SUITE_IDENTIFI
 
 ##### Arguments
 
-- `TEAMENGINE_BASE_URL` - Base URL of the teamengine service. Example: `http://localhost:8080/teamengine`
+- `TEAMENGINE_BASE_URL` - Base URL of the teamengine service. Example: `http://localhost:9080/teamengine`
 - `TEST_SUITE_IDENTIFIER` - Identifier of the test suite as known to teamengine. Look up known identifiers in the
   [section on OGC test suites](ogc-test-suites.md). Example: `ogcapi-features-1.0`
 
@@ -134,7 +137,7 @@ cite runner execute-test-suite [OPTIONS] TEAMENGINE_BASE_URL TEST_SUITE_IDENTIFI
 
     ```shell
     cite-runner execute-test-suite \
-        http://localhost:8080/teamengine \
+        http://localhost:9080/teamengine \
         ogcapi-features-1.0 \
         --suite-input iut http://localhost:5000
     ```
@@ -144,7 +147,7 @@ cite runner execute-test-suite [OPTIONS] TEAMENGINE_BASE_URL TEST_SUITE_IDENTIFI
 
     ```shell
     cite-runner execute-test-suite \
-        http://localhost:8080/teamengine \
+        http://localhost:9080/teamengine \
         ogcapi-features-1.0 \
         --suite-input iut https://demo.pygeoapi.io/stable \
         --suite-input noofcollections -1 \
@@ -160,7 +163,7 @@ cite runner execute-test-suite [OPTIONS] TEAMENGINE_BASE_URL TEST_SUITE_IDENTIFI
 
     ```shell
     cite-runner execute-test-suite \
-        http://localhost:8080/teamengine \
+        http://localhost:9080/teamengine \
         ogcapi-processes-1.0 \
         --suite-input iut http://localhost:5000 \
         --suite-input noofcollections -1 \
@@ -185,7 +188,7 @@ details from the same test run.
 
     ```shell
     cite-runner execute-test-suite \
-        http://localhost:8080/teamengine \
+        http://localhost:9080/teamengine \
         ogcapi-features-1.0 \
         --suite-input iut http://localhost:5000 \
     | cite-runner parse-result -
@@ -219,7 +222,7 @@ Accepts a subset of similar [options as the execute-test-suite-command](#options
     RAW_RESULT_PATH=raw-results.xml
 
     cite-runner execute-test-suite \
-        http://localhost:8080/teamengine \
+        http://localhost:9080/teamengine \
         ogcapi-processes-1.0 \
         --suite-input iut http://localhost:5000 \
         --suite-input noofcollections -1 \
@@ -261,7 +264,7 @@ before the command.
     ```
 
 
-
+[docker engine docs:material-open-in-new:]: https://docs.docker.com/reference/cli/docker/container/run/#add-host
 [docker image:material-open-in-new:]: https://hub.docker.com/r/ogccite/teamengine-production
 [pygeoapi demo service:material-open-in-new:]: https://demo.pygeoapi.io/stable
 [official docker documentation:material-open-in-new:]: https://docs.docker.com/engine/network/tutorials/host/#prerequisites

--- a/src/cite_runner/teamengine_runner.py
+++ b/src/cite_runner/teamengine_runner.py
@@ -41,19 +41,23 @@ def wait_for_teamengine_to_be_ready(
     current_attempt = 1
     result = False
     while current_attempt <= num_attempts:
-        response = client.get(f"{teamengine_base_url}/")
-        if response.status_code == 200:
-            result = True
-            break
-        else:
+        try:
+            response = client.get(f"{teamengine_base_url}/")
+        except (httpx.HTTPError, httpx.ConnectError):
             logger.debug("teamengine is not ready yet.")
-            if current_attempt == num_attempts:
-                logger.error("teamengine did not become ready - aborting")
+        else:
+            if response.status_code == 200:
+                result = True
                 break
             else:
-                logger.debug(f"waiting {wait_seconds}s before trying again...")
-                current_attempt += 1
-                time.sleep(wait_seconds)
+                logger.debug("teamengine is not ready yet.")
+        if current_attempt == num_attempts:
+            logger.error("teamengine did not become ready - aborting")
+            break
+        else:
+            logger.debug(f"waiting {wait_seconds}s before trying again...")
+            current_attempt += 1
+            time.sleep(wait_seconds)
     return result
 
 

--- a/tests/github_action_tests.py
+++ b/tests/github_action_tests.py
@@ -1,0 +1,45 @@
+"""These tests are meant to be run in a GitHub Action environment.
+
+These are written with the standard Python unittest framework in order to not require
+the installation of additional dependencies.
+"""
+
+import argparse
+import json
+import sys
+import unittest
+
+_RAW_JSON_REPORT: bytes | None = None
+
+
+class TestGithubAction(unittest.TestCase):
+    def setUp(self):
+        global _RAW_JSON_REPORT
+        self.parsed_report = json.loads(_RAW_JSON_REPORT)
+
+    def test_report_main_result(self):
+        self.assertFalse(self.parsed_report["passed"])
+
+    def test_report_num_failed(self):
+        self.assertEqual(self.parsed_report["num_failed_tests"], 4)
+
+    def test_report_num_skipped(self):
+        self.assertEqual(self.parsed_report["num_skipped_tests"], 36)
+
+    def test_report_num_passed(self):
+        self.assertEqual(self.parsed_report["num_passed_tests"], 2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "json_report", type=argparse.FileType("rb"), help="raw JSON report"
+    )
+    args = parser.parse_args()
+    global RAW_JSON_REPORT
+    _RAW_JSON_REPORT = args.json_report.read()
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestGithubAction)
+    runner = unittest.TextTestRunner()
+    result = runner.run(suite)
+    if not result.wasSuccessful():
+        sys.exit(1)

--- a/tests/simpleserver.py
+++ b/tests/simpleserver.py
@@ -1,0 +1,189 @@
+"""A simple HTTP server for testing CITE runner."""
+
+import dataclasses
+import json
+import logging
+import functools
+from typing import Protocol
+from http.client import HTTPMessage
+from http.server import (
+    HTTPServer,
+    BaseHTTPRequestHandler,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class Collection:
+    id: str
+    title: str
+    description: str
+    keywords: str
+    links: str
+    extent: str
+    item_type: str
+    crs: str
+    storage_crs: str
+
+
+class DataCatalog:
+    collections: dict[str, Collection]
+
+    def __init__(self):
+        self.collections = {
+            "test-collection-1": Collection(
+                id="test-collection-1",
+                title="Test Collection 1",
+                description="This is a test collection",
+                keywords="test, collection, 1",
+                links="https://example.com/test-collection-1",
+                extent="100, 100",
+                item_type="test-item-type",
+                crs="EPSG:4326",
+                storage_crs="EPSG:4326",
+            ),
+        }
+
+    def list_collections(self) -> list[Collection]:
+        return self.collections
+
+    def get_collection(self, collection_id: str) -> Collection: ...
+
+
+@functools.cache
+def get_catalog():
+    return DataCatalog()
+
+
+class RequestHandler(Protocol):
+    def __call__(
+        self,
+        headers: HTTPMessage,
+        query: str | None = None,
+        encoding: str = "utf-8",
+        **path_parameters: dict[str:str],
+    ) -> tuple[int, dict[str, str], bytes]: ...
+
+
+class CiteRunnerApiFeaturesHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        encoding = "utf-8"
+        path, query = self.path.partition("?")[::2]
+        path = path.strip("/")
+        logger.debug(f"{self.path=}")
+        logger.debug(f"path={path!r}, query={query!r}")
+        handler_info = select_handler(path)
+        if handler_info is not None:
+            try:
+                handler, path_parameters = handler_info
+            except TypeError:
+                handler = handler_info
+                path_parameters = {}
+            status, headers, body = handler(
+                self.headers, query=query, encoding=encoding, **path_parameters
+            )
+        else:
+            status, headers, body = (
+                404,
+                {
+                    "Content-type": f"application/json; charset={encoding}",
+                },
+                json.dumps({"error": "Not found"}).encode(encoding),
+            )
+        self.send_response(status)
+        for key, value in headers.items():
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def select_handler(
+    path: str,
+) -> RequestHandler | RequestHandler | tuple[RequestHandler, dict[str, str]] | None:
+    match path.split("/"):
+        case [""]:
+            return get_landing_page
+        case ["collections"]:
+            return list_collections
+        case ["collections", collection_id]:
+            return get_collection, {"collection_id": collection_id}
+        case _:
+            return None
+
+
+def get_landing_page(
+    headers: HTTPMessage, query: str | None = None, encoding: str = "utf-8"
+) -> tuple[int, dict[str, str], bytes]:
+    return (
+        200,
+        {
+            "Content-type": f"application/json; charset={encoding}",
+        },
+        json.dumps(
+            {
+                "collections": [],
+                "links": [
+                    {
+                        "type": "application/json",
+                        "rel": "self",
+                        "title": "This document",
+                        "href": "",
+                    }
+                ],
+            },
+        ).encode(encoding),
+    )
+
+
+def list_collections(
+    headers: HTTPMessage, query: str | None = None, encoding: str = "utf-8"
+) -> tuple[int, dict[str, str], bytes]:
+    catalog = get_catalog()
+    serialized_collections = []
+    for collection in catalog.list_collections():
+        serialized_collections.append(dataclasses.asdict(collection))
+
+    return (
+        200,
+        {
+            "Content-type": f"application/json; charset={encoding}",
+        },
+        json.dumps(
+            {
+                "original_query_was": query,
+                "collections": serialized_collections,
+            },
+        ).encode(encoding),
+    )
+
+
+def get_collection(
+    headers: HTTPMessage,
+    query: str | None = None,
+    encoding: str = "utf-8",
+    *,
+    collection_id: str,
+) -> tuple[int, dict[str, str], bytes]:
+    return (
+        200,
+        {
+            "Content-type": f"application/json; charset={encoding}",
+        },
+        json.dumps(
+            {
+                "collection_id_was": collection_id,
+                "original_query_was": query,
+            },
+        ).encode(encoding),
+    )
+
+
+def main(bind_address: str = "localhost", port: int = 8000):
+    httpd = HTTPServer((bind_address, port), CiteRunnerApiFeaturesHandler)
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    main()

--- a/tests/simpleserver.py
+++ b/tests/simpleserver.py
@@ -1,7 +1,7 @@
 """A simple HTTP server for testing CITE runner's GitHub action.
 
-This is server that purposedly does not fully implement OGC API Features. The intention
-is to use this to test cite-runner's ability to be called as a GitHub action.
+This is a server that purposedly does not fully implement OGC API Features. The
+intention is to use this to test cite-runner's ability to be called as a GitHub action.
 """
 
 import argparse

--- a/tests/simpleserver.py
+++ b/tests/simpleserver.py
@@ -117,7 +117,6 @@ class DataCatalog:
                 title="Test Collection 1",
                 description="This is a test collection",
                 keywords="test, collection, 1",
-                links="https://example.com/test-collection-1",
                 extent="100, 100",
                 item_type="test-item-type",
                 crs="EPSG:4326",

--- a/tests/simpleserver.py
+++ b/tests/simpleserver.py
@@ -1,17 +1,91 @@
-"""A simple HTTP server for testing CITE runner."""
+"""A simple HTTP server for testing CITE runner's GitHub action.
 
+This is server that purposedly does not fully implement OGC API Features. The intention
+is to use this to test cite-runner's ability to be called as a GitHub action.
+"""
+
+import argparse
 import dataclasses
 import json
 import logging
-import functools
-from typing import Protocol
+from typing import (
+    Protocol,
+    Type,
+)
 from http.client import HTTPMessage
 from http.server import (
     HTTPServer,
     BaseHTTPRequestHandler,
 )
+import urllib.parse
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class HttpRequest:
+    headers: dict[str, str]
+    url: urllib.parse.ParseResult
+
+    @property
+    def base_url(self) -> str:
+        return "{scheme}://{host}/".format(
+            scheme=self.url.scheme,
+            host=self.url.netloc,
+        )
+
+    @classmethod
+    def from_raw_request(
+        cls: Type["HttpRequest"], raw_headers: HTTPMessage, raw_path: str
+    ) -> "HttpRequest":
+        parsed_headers = parse_headers(raw_headers)
+        parsed_url = parse_url(parsed_headers.get("Host", ""), raw_path)
+        return HttpRequest(
+            headers=parsed_headers,
+            url=parsed_url,
+        )
+
+
+def parse_headers(raw_headers: HTTPMessage) -> dict[str, str | list[str]]:
+    result = {}
+    for name in raw_headers.keys():
+        value = raw_headers.get_all(name)
+        if len(value) == 1:
+            result[name] = value[0]
+        else:
+            result[name] = value
+    return result
+
+
+def parse_url(host: str, path: str) -> urllib.parse.ParseResult:
+    scheme = "http"
+    full_url = f"{scheme}://{host}{path}"
+    return urllib.parse.urlparse(full_url)
+
+
+@dataclasses.dataclass
+class OgcApiLink:
+    href: str
+    rel: str
+    title: str
+    type: str
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class OgcApiLandingPage:
+    title: str
+    description: str
+    links: list[OgcApiLink]
+
+    def to_dict(self) -> dict:
+        return {
+            "title": self.title,
+            "description": self.description,
+            "links": [link.to_dict() for link in self.links],
+        }
 
 
 @dataclasses.dataclass
@@ -20,17 +94,23 @@ class Collection:
     title: str
     description: str
     keywords: str
-    links: str
     extent: str
     item_type: str
     crs: str
     storage_crs: str
 
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
 
 class DataCatalog:
+    title: str
+    description: str
     collections: dict[str, Collection]
 
-    def __init__(self):
+    def __init__(self, title: str, description: str):
+        self.title = title
+        self.description = description
         self.collections = {
             "test-collection-1": Collection(
                 id="test-collection-1",
@@ -46,34 +126,31 @@ class DataCatalog:
         }
 
     def list_collections(self) -> list[Collection]:
-        return self.collections
+        return list(self.collections.values())
 
-    def get_collection(self, collection_id: str) -> Collection: ...
-
-
-@functools.cache
-def get_catalog():
-    return DataCatalog()
+    def get_collection(self, collection_id: str) -> Collection | None:
+        return self.collections.get(collection_id)
 
 
-class RequestHandler(Protocol):
+class OgcApiRequestHandler(Protocol):
     def __call__(
         self,
-        headers: HTTPMessage,
-        query: str | None = None,
+        catalog: DataCatalog,
+        request: HttpRequest,
         encoding: str = "utf-8",
         **path_parameters: dict[str:str],
     ) -> tuple[int, dict[str, str], bytes]: ...
 
 
 class CiteRunnerApiFeaturesHandler(BaseHTTPRequestHandler):
+    catalog: DataCatalog
+
     def do_GET(self):
         encoding = "utf-8"
-        path, query = self.path.partition("?")[::2]
-        path = path.strip("/")
-        logger.debug(f"{self.path=}")
-        logger.debug(f"path={path!r}, query={query!r}")
-        handler_info = select_handler(path)
+        request = HttpRequest.from_raw_request(self.headers, self.path)
+        logger.debug(f"{request=}")
+        handler_info = select_handler(request)
+        logger.debug(f"{handler_info=}")
         if handler_info is not None:
             try:
                 handler, path_parameters = handler_info
@@ -81,7 +158,7 @@ class CiteRunnerApiFeaturesHandler(BaseHTTPRequestHandler):
                 handler = handler_info
                 path_parameters = {}
             status, headers, body = handler(
-                self.headers, query=query, encoding=encoding, **path_parameters
+                self.catalog, request, encoding=encoding, **path_parameters
             )
         else:
             status, headers, body = (
@@ -99,9 +176,14 @@ class CiteRunnerApiFeaturesHandler(BaseHTTPRequestHandler):
 
 
 def select_handler(
-    path: str,
-) -> RequestHandler | RequestHandler | tuple[RequestHandler, dict[str, str]] | None:
-    match path.split("/"):
+    request: HttpRequest,
+) -> (
+    OgcApiRequestHandler
+    | OgcApiRequestHandler
+    | tuple[OgcApiRequestHandler, dict[str, str]]
+    | None
+):
+    match request.url.path.split("/")[1:]:
         case [""]:
             return get_landing_page
         case ["collections"]:
@@ -113,36 +195,55 @@ def select_handler(
 
 
 def get_landing_page(
-    headers: HTTPMessage, query: str | None = None, encoding: str = "utf-8"
+    catalog: DataCatalog, request: HttpRequest, encoding: str = "utf-8"
 ) -> tuple[int, dict[str, str], bytes]:
+    json_media_type = "application/json"
+    openapi_v3_media_type = "application/vnd.oai.openapi+json;version=3.0"
+    landing_page = OgcApiLandingPage(
+        title=catalog.title,
+        description=catalog.description,
+        links=[
+            OgcApiLink(
+                href=f"{request.base_url}",
+                rel="self",
+                title="This document",
+                type=json_media_type,
+            ),
+            OgcApiLink(
+                href=f"{request.base_url}openapi",
+                rel="service-desc",
+                title="OpenAPI definition",
+                type=openapi_v3_media_type,
+            ),
+            OgcApiLink(
+                href=f"{request.base_url}conformance",
+                rel="conformance",
+                title="Conformance",
+                type=json_media_type,
+            ),
+            OgcApiLink(
+                href=f"{request.base_url}collections",
+                rel="data",
+                title="Collections",
+                type=json_media_type,
+            ),
+        ],
+    )
     return (
         200,
         {
-            "Content-type": f"application/json; charset={encoding}",
+            "Content-type": f"{json_media_type}; charset={encoding}",
         },
-        json.dumps(
-            {
-                "collections": [],
-                "links": [
-                    {
-                        "type": "application/json",
-                        "rel": "self",
-                        "title": "This document",
-                        "href": "",
-                    }
-                ],
-            },
-        ).encode(encoding),
+        json.dumps(landing_page.to_dict()).encode(encoding),
     )
 
 
 def list_collections(
-    headers: HTTPMessage, query: str | None = None, encoding: str = "utf-8"
+    catalog: DataCatalog, request: HttpRequest, encoding: str = "utf-8"
 ) -> tuple[int, dict[str, str], bytes]:
-    catalog = get_catalog()
     serialized_collections = []
     for collection in catalog.list_collections():
-        serialized_collections.append(dataclasses.asdict(collection))
+        serialized_collections.append(collection.to_dict())
 
     return (
         200,
@@ -150,17 +251,14 @@ def list_collections(
             "Content-type": f"application/json; charset={encoding}",
         },
         json.dumps(
-            {
-                "original_query_was": query,
-                "collections": serialized_collections,
-            },
+            {"collections": serialized_collections, "links": []},
         ).encode(encoding),
     )
 
 
 def get_collection(
-    headers: HTTPMessage,
-    query: str | None = None,
+    catalog: DataCatalog,
+    request: HttpRequest,
     encoding: str = "utf-8",
     *,
     collection_id: str,
@@ -173,17 +271,33 @@ def get_collection(
         json.dumps(
             {
                 "collection_id_was": collection_id,
-                "original_query_was": query,
             },
         ).encode(encoding),
     )
 
 
-def main(bind_address: str = "localhost", port: int = 8000):
+def main(bind_address: str, port: int):
+    CiteRunnerApiFeaturesHandler.catalog = DataCatalog(
+        title="Simple server",
+        description="A basic OGC API Features server, built for testing cite-runner as a GitHub Action.",
+    )
+    logger.info(f"Launching {CiteRunnerApiFeaturesHandler.catalog.title!r}...")
+    logger.info(f"Listening on http://{bind_address}:{port}")
     httpd = HTTPServer((bind_address, port), CiteRunnerApiFeaturesHandler)
     httpd.serve_forever()
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
-    main()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "-b", "--bind-address", default="localhost", help="Address to bind to"
+    )
+    parser.add_argument("-p", "--bind-port", default="8000", help="Port to bind to")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose logging"
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+    main(bind_address=args.bind_address, port=int(args.bind_port))


### PR DESCRIPTION
This PR adds a workflow for testing cite-runner's github action.

It includes:

- A workflow that uses cite-runner as an action
- A simple HTTP app that implements only a very small subset of ogcapi features to be used for testing cite-runner
- Some Python tests for checking if cite-runner action ran as expected
- Updated development-related docs
- A new output of cite-runner, which is the full execution result as a JSON document

---

- fixes #86
- fixes #94