### PR TITLE
Add missing port publishing on the main example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ docker run \
     --rm \
     --name=teamengine \
     --add-host=host.docker.internal:host-gateway \
+    --publish=9080:8080 \
     ogccite/teamengine-production:1.0-SNAPSHOT
 
 pipx install cite-runner


### PR DESCRIPTION
This is a follow-up for #100, whereby I had forgotten to modify one of the examples