### PR TITLE
Added missing slash in command

### DIFF
--- a/docs/running-as-standalone-cli.md
+++ b/docs/running-as-standalone-cli.md
@@ -195,7 +195,7 @@ cite runner execute-test-suite [OPTIONS] TEAMENGINE_BASE_URL TEST_SUITE_IDENTIFI
         ogcapi-processes-1.0 \
         --suite-input iut http://host.docker.internal:5000 \
         --suite-input noofcollections -1 \
-        --output-format json
+        --output-format json \
     | jq '.passed'
     ```
 


### PR DESCRIPTION
This PR ensures that the multi-line command showed in the documentation works.